### PR TITLE
Implement UV-Vis file ingestion for Helios and generic formats

### DIFF
--- a/spectro_app/engine/io_common.py
+++ b/spectro_app/engine/io_common.py
@@ -1,3 +1,52 @@
-def sniff_locale(sample: str) -> dict:
-    """Placeholder: detect decimal separator, delimiter, etc."""
-    return {"decimal": ".", "delimiter": ","}
+from __future__ import annotations
+
+import csv
+import re
+from typing import Dict
+
+
+def sniff_locale(sample: str) -> Dict[str, str]:
+    """Infer delimiter and decimal separator from a text sample.
+
+    The heuristics intentionally favour robustness over strict correctness –
+    Helios exports as well as ad-hoc CSV files often mix locale specific
+    decimal separators and delimiters.  We prioritise recognising decimal
+    commas so downstream parsing can substitute the delimiter accordingly.
+    """
+
+    if not sample:
+        return {"decimal": ".", "delimiter": ","}
+
+    # Normalise newlines and remove obviously empty lines to improve sniffing.
+    lines = [ln for ln in sample.splitlines() if ln.strip()]
+    trimmed = "\n".join(lines)
+
+    # Detect decimal separator by counting dot/comma occurrences between digits.
+    dot_matches = re.findall(r"\d\.\d", trimmed)
+    comma_matches = re.findall(r"\d,\d", trimmed)
+    decimal = "," if len(comma_matches) > len(dot_matches) else "."
+
+    # Try csv.Sniffer first; fall back to manual counting if it fails.
+    delimiter = None
+    try:
+        dialect = csv.Sniffer().sniff(trimmed, delimiters=",;\t")
+        delimiter = dialect.delimiter
+    except (csv.Error, ValueError):
+        pass
+
+    if not delimiter:
+        counts = {sep: trimmed.count(sep) for sep in (";", "\t", ",")}
+        # If comma is the decimal separator, discount those occurrences.
+        if decimal == ",":
+            counts[","] = max(0, counts[","] - len(comma_matches))
+        delimiter = max(counts, key=counts.get)
+        if counts[delimiter] == 0:
+            delimiter = ","
+
+    # Avoid conflicting comma-as-decimal with comma-as-delimiter when possible.
+    if delimiter == "," and decimal == ",":
+        delimiter = ";" if ";" in trimmed else "\t"
+        if delimiter in {None, "\t"} and "\t" not in trimmed:
+            delimiter = ","
+
+    return {"decimal": decimal, "delimiter": delimiter or ","}

--- a/spectro_app/plugins/uvvis/io_helios.py
+++ b/spectro_app/plugins/uvvis/io_helios.py
@@ -1,1 +1,382 @@
-# Placeholder for tolerant Helios parser
+from __future__ import annotations
+
+import io
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import pandas as pd
+
+from spectro_app.engine.io_common import sniff_locale
+
+
+KEY_ALIASES = {
+    "instrument": "instrument",
+    "instrument name": "instrument",
+    "model": "instrument_model",
+    "model name": "instrument_model",
+    "serial": "instrument_serial",
+    "serial number": "instrument_serial",
+    "mode": "mode_raw",
+    "measurement mode": "mode_raw",
+    "method": "mode_raw",
+    "pathlength": "pathlength_raw",
+    "path length": "pathlength_raw",
+    "cell length": "pathlength_raw",
+    "cell pathlength": "pathlength_raw",
+    "sample id": "sample_id",
+    "sample": "sample_id",
+    "sample name": "sample_id",
+    "reference id": "blank_id",
+    "blank": "blank_id",
+    "blank id": "blank_id",
+    "operator": "operator",
+    "user": "operator",
+    "acquired by": "operator",
+    "scan speed": "scan_speed",
+    "scan rate": "scan_speed",
+    "averages": "averages",
+    "# averages": "averages",
+    "averaging": "averages",
+    "bandwidth": "bandwidth_raw",
+    "slit width": "bandwidth_raw",
+    "data": "datetime_raw",
+    "date": "date_raw",
+    "time": "time_raw",
+    "timestamp": "datetime_raw",
+    "comment": "comment",
+}
+
+
+HELIOS_KEYWORDS = (
+    "helios",
+    "gamma",
+    "sample id",
+    "reference id",
+    "scan speed",
+    "pathlength",
+    "measurement mode",
+)
+
+
+def is_helios_file(path: Path | str, sample: Optional[str] = None) -> bool:
+    """Best-effort heuristic to identify Helios Gamma exports."""
+
+    path = Path(path)
+    suffix = path.suffix.lower()
+    if suffix == ".dsp":
+        return True
+
+    if sample is None:
+        try:
+            if suffix in {".csv", ".txt"}:
+                sample = path.read_text(encoding="utf-8", errors="ignore")[:4000]
+            elif suffix in {".xls", ".xlsx"}:
+                peek = pd.read_excel(path, nrows=6, header=None)
+                sample = "\n".join(
+                    " ".join(str(v).lower() for v in row if not pd.isna(v))
+                    for row in peek.to_numpy()
+                )
+            else:
+                sample = ""
+        except Exception:
+            sample = ""
+
+    lowered = (sample or "").lower()
+    return any(keyword in lowered for keyword in HELIOS_KEYWORDS)
+
+
+def read_helios(path: Path | str) -> List[Dict[str, Any]]:
+    """Parse Helios Gamma CSV/Excel exports into tabular spectra."""
+
+    path = Path(path)
+    suffix = path.suffix.lower()
+
+    if suffix in {".csv", ".txt", ".dsp"}:
+        records = _read_helios_text(path)
+    elif suffix in {".xls", ".xlsx"}:
+        records = _read_helios_excel(path)
+    else:
+        raise ValueError(f"Unsupported Helios file type: {suffix}")
+
+    for rec in records:
+        meta = rec.setdefault("meta", {})
+        meta.setdefault("source_type", "helios_gamma")
+        meta.setdefault("instrument", "Helios Gamma")
+        meta.setdefault("technique", "uvvis")
+        meta.setdefault("source_file", str(path))
+    return records
+
+
+def parse_metadata_lines(lines: Iterable[str]) -> Dict[str, Any]:
+    meta: Dict[str, Any] = {}
+    kv_pairs: Dict[str, Any] = {}
+    for raw_line in lines:
+        line = raw_line.strip().strip("#")
+        if not line:
+            continue
+        for sep in (":", "=", ";", "\t"):
+            if sep in line:
+                left, right = line.split(sep, 1)
+                key = left.strip().lower()
+                value = right.strip()
+                if key:
+                    kv_pairs[key] = value
+                break
+
+    for key, value in kv_pairs.items():
+        mapped = KEY_ALIASES.get(key, key)
+        if mapped == "mode_raw":
+            meta["mode"] = _normalise_mode(value)
+        elif mapped == "pathlength_raw":
+            meta["pathlength_cm"] = _parse_pathlength(value)
+        elif mapped == "bandwidth_raw":
+            meta["bandwidth_nm"] = _parse_float(value)
+        elif mapped == "averages":
+            parsed = _parse_float(value)
+            if parsed is not None:
+                meta["averages"] = int(round(parsed))
+        elif mapped == "datetime_raw":
+            parsed = _parse_datetime(value)
+            if parsed:
+                meta["acquired_datetime"] = parsed.isoformat()
+        elif mapped == "date_raw":
+            parsed = _parse_datetime(value)
+            if parsed:
+                existing = meta.get("acquired_datetime")
+                if existing:
+                    # Merge only if time missing; otherwise prefer original.
+                    dt = datetime.fromisoformat(existing)
+                    meta["acquired_datetime"] = datetime.combine(
+                        parsed.date(), dt.time()
+                    ).isoformat()
+                else:
+                    meta["acquired_datetime"] = parsed.date().isoformat()
+        elif mapped == "time_raw":
+            parsed = _parse_datetime(value)
+            if parsed:
+                existing = meta.get("acquired_datetime")
+                time_str = parsed.time().isoformat()
+                if existing and len(existing) > 10:
+                    dt = datetime.fromisoformat(existing)
+                    meta["acquired_datetime"] = datetime.combine(
+                        dt.date(), parsed.time()
+                    ).isoformat()
+                else:
+                    meta["acquired_time"] = time_str
+        else:
+            meta[mapped] = value
+
+    if "acquired_datetime" not in meta:
+        # Compose from separate date/time entries if both were provided.
+        date_part = kv_pairs.get("date") or kv_pairs.get("data")
+        time_part = kv_pairs.get("time")
+        if date_part or time_part:
+            parsed = _compose_datetime(date_part, time_part)
+            if parsed:
+                meta["acquired_datetime"] = parsed.isoformat()
+
+    return meta
+
+
+def _read_helios_text(path: Path) -> List[Dict[str, Any]]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    locale = sniff_locale(text)
+    lines = text.splitlines()
+    header_idx, has_header, meta_lines = _locate_table(
+        lines, locale["delimiter"], locale["decimal"]
+    )
+    data_str = "\n".join(lines[header_idx:])
+    df = pd.read_csv(
+        io.StringIO(data_str),
+        sep=locale["delimiter"] if locale["delimiter"] else None,
+        decimal=locale["decimal"],
+        engine="python",
+        header=0 if has_header else None,
+    )
+    if not has_header:
+        df_columns = [f"col_{idx}" for idx in range(df.shape[1])]
+        df.columns = df_columns
+
+    meta = parse_metadata_lines(meta_lines)
+    return _dataframe_to_records(df, meta)
+
+
+def _read_helios_excel(path: Path) -> List[Dict[str, Any]]:
+    raw = pd.read_excel(path, header=None)
+    rows_as_text = [
+        "\t".join(str(v) for v in row if not pd.isna(v))
+        for row in raw.itertuples(index=False, name=None)
+    ]
+    header_idx, has_header, meta_lines = _locate_table(rows_as_text, "\t", ".")
+    if has_header:
+        df = pd.read_excel(path, header=header_idx)
+    else:
+        df = pd.read_excel(path, header=None, skiprows=header_idx)
+        df.columns = [f"col_{idx}" for idx in range(df.shape[1])]
+
+    df = df.dropna(axis=1, how="all")
+    meta = parse_metadata_lines(meta_lines)
+    return _dataframe_to_records(df, meta)
+
+
+def _dataframe_to_records(df: pd.DataFrame, base_meta: Dict[str, Any]) -> List[Dict[str, Any]]:
+    df = df.dropna(how="all")
+    df.columns = [str(col).strip() for col in df.columns]
+    if df.shape[1] < 2:
+        raise ValueError("Helios export must contain wavelength and at least one intensity column")
+
+    wavelength = pd.to_numeric(df.iloc[:, 0], errors="coerce")
+    records: List[Dict[str, Any]] = []
+    for idx, column in enumerate(df.columns[1:], start=1):
+        intensity = pd.to_numeric(df.iloc[:, idx], errors="coerce")
+        mask = wavelength.notna() & intensity.notna()
+        wl = wavelength[mask].to_numpy(dtype=float)
+        inten = intensity[mask].to_numpy(dtype=float)
+        if wl.size == 0:
+            continue
+        column_meta = dict(base_meta)
+        column_meta.setdefault("channel", column)
+        # Sample/blank hints fall back to column naming when explicit IDs absent.
+        if "sample_id" not in column_meta or not column_meta["sample_id"]:
+            column_meta["sample_id"] = column
+        role = _infer_role(column, column_meta)
+        column_meta.setdefault("role", role)
+        if role == "blank":
+            column_meta.setdefault("blank_id", column_meta.get("sample_id", column))
+        records.append(
+            {
+                "wavelength": wl,
+                "intensity": inten,
+                "meta": column_meta,
+            }
+        )
+    return records
+
+
+def _locate_table(lines: Sequence[str], delimiter: Optional[str], decimal: str) -> tuple[int, bool, List[str]]:
+    numeric_idx: Optional[int] = None
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        tokens = _tokenise(stripped, delimiter)
+        numeric_tokens = sum(1 for tok in tokens if _is_number(tok, decimal))
+        if numeric_tokens >= 2:
+            numeric_idx = idx
+            break
+    if numeric_idx is None:
+        raise ValueError("Unable to locate numeric data rows in Helios export")
+
+    header_idx = numeric_idx
+    if numeric_idx > 0:
+        prev_tokens = _tokenise(lines[numeric_idx - 1], delimiter)
+        if prev_tokens and not all(_is_number(tok, decimal) for tok in prev_tokens):
+            header_idx = numeric_idx - 1
+
+    meta_lines = [line for line in lines[:header_idx] if line and line.strip()]
+    has_header = header_idx != numeric_idx
+    return header_idx, has_header, meta_lines
+
+
+def _tokenise(line: str, delimiter: Optional[str]) -> List[str]:
+    if delimiter and delimiter.strip():
+        return [token.strip() for token in line.split(delimiter)]
+    return line.split()
+
+
+def _is_number(token: str, decimal: str) -> bool:
+    token = token.strip()
+    if not token:
+        return False
+    if decimal != ".":
+        token = token.replace(decimal, ".")
+    token = token.replace(" ", "")
+    try:
+        float(token)
+        return True
+    except ValueError:
+        return False
+
+
+def _normalise_mode(value: str | None) -> Optional[str]:
+    if value is None:
+        return None
+    val = str(value).strip().lower()
+    if not val:
+        return None
+    if val.startswith("abs") or "absorb" in val:
+        return "absorbance"
+    if "%t" in val or "trans" in val:
+        return "transmittance"
+    if "reflect" in val:
+        return "reflectance"
+    return val
+
+
+def _parse_pathlength(value: str | None) -> Optional[float]:
+    if not value:
+        return None
+    match = re.search(r"([\d.,]+)\s*(mm|cm|m|µm|um)?", value, re.IGNORECASE)
+    if not match:
+        return _parse_float(value)
+    magnitude = _parse_float(match.group(1))
+    if magnitude is None:
+        return None
+    unit = (match.group(2) or "cm").lower()
+    if unit == "cm":
+        return magnitude
+    if unit == "mm":
+        return magnitude / 10.0
+    if unit in {"m"}:
+        return magnitude * 100.0
+    if unit in {"µm", "um"}:
+        return magnitude / 10000.0
+    return magnitude
+
+
+def _parse_float(value: str | None) -> Optional[float]:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    if not cleaned:
+        return None
+    cleaned = cleaned.replace("µ", "u").replace(" ", "")
+    if cleaned.count(",") > cleaned.count("."):
+        cleaned = cleaned.replace(".", "").replace(",", ".")
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def _parse_datetime(value: str | None) -> Optional[datetime]:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    for dayfirst in (True, False):
+        parsed = pd.to_datetime(text, errors="coerce", dayfirst=dayfirst)
+        if not pd.isna(parsed):
+            return parsed.to_pydatetime()
+    return None
+
+
+def _compose_datetime(date_value: Optional[str], time_value: Optional[str]) -> Optional[datetime]:
+    date_part = _parse_datetime(date_value)
+    time_part = _parse_datetime(time_value)
+    if date_part and time_part:
+        return datetime.combine(date_part.date(), time_part.time())
+    return date_part or time_part
+
+
+def _infer_role(column: str, meta: Dict[str, Any]) -> str:
+    column_lower = column.lower()
+    blank_id = str(meta.get("blank_id", "")).lower()
+    if "blank" in column_lower or "reference" in column_lower:
+        return "blank"
+    if blank_id and blank_id in column_lower:
+        return "blank"
+    return "sample"

--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -1,5 +1,15 @@
-from spectro_app.engine.plugin_api import SpectroscopyPlugin, Spectrum, BatchResult
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Dict, Iterable, List
+
 import numpy as np
+import pandas as pd
+
+from spectro_app.engine.io_common import sniff_locale
+from spectro_app.engine.plugin_api import BatchResult, SpectroscopyPlugin, Spectrum
+from .io_helios import is_helios_file, parse_metadata_lines, read_helios
 
 class UvVisPlugin(SpectroscopyPlugin):
     id = "uvvis"
@@ -7,13 +17,195 @@ class UvVisPlugin(SpectroscopyPlugin):
     xlabel = "Wavelength (nm)"
 
     def detect(self, paths):
-        return any(str(p).lower().endswith((".dsp", ".csv", ".xlsx")) for p in paths)
+        return any(str(p).lower().endswith((".dsp", ".csv", ".xlsx", ".txt")) for p in paths)
 
-    def load(self, paths):
-        # Placeholder: return a fake spectrum for scaffold purposes
-        wl = np.linspace(200, 900, 701)
-        inten = np.zeros_like(wl)
-        return [Spectrum(wavelength=wl, intensity=inten, meta={"source": "stub"})]
+    def load(self, paths: Iterable[str]) -> List[Spectrum]:
+        spectra: List[Spectrum] = []
+        for path_str in paths:
+            path = Path(path_str)
+            suffix = path.suffix.lower()
+            file_records: List[Dict[str, object]]
+
+            if suffix in {".dsp"}:
+                file_records = read_helios(path)
+            elif suffix in {".csv", ".txt"}:
+                text_sample = path.read_text(encoding="utf-8", errors="ignore")[:4000]
+                if is_helios_file(path, text_sample):
+                    file_records = read_helios(path)
+                else:
+                    file_records = self._read_generic_text(path, text_sample)
+            elif suffix in {".xls", ".xlsx"}:
+                if is_helios_file(path):
+                    file_records = read_helios(path)
+                else:
+                    file_records = self._read_generic_excel(path)
+            else:
+                raise ValueError(f"Unsupported UV-Vis file type: {suffix}")
+
+            for record in file_records:
+                wl = np.asarray(record["wavelength"], dtype=float)
+                inten = np.asarray(record["intensity"], dtype=float)
+                meta = dict(record.get("meta", {}))
+                meta.setdefault("technique", "uvvis")
+                meta.setdefault("source_file", str(path))
+                spectra.append(Spectrum(wavelength=wl, intensity=inten, meta=meta))
+
+        return spectra
+
+    # ------------------------------------------------------------------
+    # Generic CSV/Excel ingestion helpers
+    def _read_generic_text(self, path: Path, sample: str) -> List[Dict[str, object]]:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        locale = sniff_locale(text or sample)
+        lines = text.splitlines()
+        header_idx, has_header, meta_lines = self._locate_table(
+            lines, locale["delimiter"], locale["decimal"]
+        )
+        data_str = "\n".join(lines[header_idx:])
+        df = pd.read_csv(
+            io.StringIO(data_str),
+            sep=locale["delimiter"] if locale["delimiter"] else None,
+            decimal=locale["decimal"],
+            engine="python",
+            header=0 if has_header else None,
+        )
+        if not has_header:
+            df.columns = [f"col_{idx}" for idx in range(df.shape[1])]
+
+        return self._dataframe_to_records(df, meta_lines, {
+            "source_type": "generic_csv",
+            "instrument": "Generic UV-Vis",
+        })
+
+    def _read_generic_excel(self, path: Path) -> List[Dict[str, object]]:
+        raw = pd.read_excel(path, header=None)
+        rows_as_text = [
+            "\t".join(str(v) for v in row if not pd.isna(v))
+            for row in raw.itertuples(index=False, name=None)
+        ]
+        header_idx, has_header, meta_lines = self._locate_table(rows_as_text, "\t", ".")
+        if has_header:
+            df = pd.read_excel(path, header=header_idx)
+        else:
+            df = pd.read_excel(path, header=None, skiprows=header_idx)
+            df.columns = [f"col_{idx}" for idx in range(df.shape[1])]
+
+        df = df.dropna(axis=1, how="all")
+        return self._dataframe_to_records(df, meta_lines, {
+            "source_type": "generic_excel",
+            "instrument": "Generic UV-Vis",
+        })
+
+    def _dataframe_to_records(
+        self,
+        df: pd.DataFrame,
+        meta_lines: Iterable[str],
+        base_meta: Dict[str, object],
+    ) -> List[Dict[str, object]]:
+        df = df.dropna(how="all")
+        df.columns = [str(col).strip() for col in df.columns]
+        if df.shape[1] < 2:
+            raise ValueError("Tabular UV-Vis file must contain wavelength and one intensity column")
+
+        parsed_meta = parse_metadata_lines(meta_lines)
+        meta: Dict[str, object] = {**base_meta, **parsed_meta}
+        meta.setdefault("technique", "uvvis")
+        mode = meta.get("mode")
+        if not mode:
+            mode = self._infer_mode_from_headers(df.columns[1:])
+            if mode:
+                meta["mode"] = mode
+
+        wavelength = pd.to_numeric(df.iloc[:, 0], errors="coerce")
+        intensity_columns = df.columns[1:]
+        blank_candidates = [col for col in intensity_columns if self._infer_role(col) == "blank"]
+        records: List[Dict[str, object]] = []
+        for idx, column in enumerate(intensity_columns, start=1):
+            intensities = pd.to_numeric(df.iloc[:, idx], errors="coerce")
+            mask = wavelength.notna() & intensities.notna()
+            wl = wavelength[mask].to_numpy(dtype=float)
+            inten = intensities[mask].to_numpy(dtype=float)
+            if wl.size == 0:
+                continue
+            column_meta = dict(meta)
+            column_meta.setdefault("channel", column)
+            column_meta.setdefault("sample_id", column)
+            role = self._infer_role(column)
+            column_meta.setdefault("role", role)
+            if role == "sample" and blank_candidates:
+                column_meta.setdefault("blank_id", blank_candidates[0])
+            if role == "blank":
+                column_meta.setdefault("blank_id", column)
+            records.append({
+                "wavelength": wl,
+                "intensity": inten,
+                "meta": column_meta,
+            })
+        return records
+
+    def _locate_table(self, lines: Iterable[str], delimiter: str | None, decimal: str):
+        lines = list(lines)
+        numeric_idx = None
+        for idx, line in enumerate(lines):
+            stripped = str(line).strip()
+            if not stripped:
+                continue
+            tokens = self._tokenise(stripped, delimiter)
+            numeric_tokens = sum(1 for token in tokens if self._is_number(token, decimal))
+            if numeric_tokens >= 2:
+                numeric_idx = idx
+                break
+        if numeric_idx is None:
+            raise ValueError("Unable to locate numeric data rows in UV-Vis file")
+
+        header_idx = numeric_idx
+        if numeric_idx > 0:
+            prev_tokens = self._tokenise(lines[numeric_idx - 1], delimiter)
+            if prev_tokens and not all(self._is_number(tok, decimal) for tok in prev_tokens):
+                header_idx = numeric_idx - 1
+
+        meta_lines = [line for line in lines[:header_idx] if str(line).strip()]
+        has_header = header_idx != numeric_idx
+        return header_idx, has_header, meta_lines
+
+    @staticmethod
+    def _tokenise(line: str, delimiter: str | None):
+        if delimiter and delimiter.strip():
+            return [token.strip() for token in line.split(delimiter)]
+        return line.split()
+
+    @staticmethod
+    def _is_number(token: str, decimal: str) -> bool:
+        token = token.strip()
+        if not token:
+            return False
+        if decimal != ".":
+            token = token.replace(decimal, ".")
+        token = token.replace(" ", "")
+        try:
+            float(token)
+            return True
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _infer_role(label: str) -> str:
+        lower = label.lower()
+        if "blank" in lower or "reference" in lower or lower.startswith("ref"):
+            return "blank"
+        return "sample"
+
+    @staticmethod
+    def _infer_mode_from_headers(headers: Iterable[str]) -> str | None:
+        for header in headers:
+            lower = str(header).lower()
+            if "abs" in lower:
+                return "absorbance"
+            if "%t" in lower or "trans" in lower:
+                return "transmittance"
+            if "%r" in lower or "reflect" in lower:
+                return "reflectance"
+        return None
 
     def preprocess(self, specs, recipe):
         # TODO: implement: to_absorbance, blank mapping, baseline, join fix, despike, SG

--- a/spectro_app/tests/test_io_uvvis.py
+++ b/spectro_app/tests/test_io_uvvis.py
@@ -1,2 +1,93 @@
-def test_stub_io_uvvis():
-    assert True
+import numpy as np
+import pandas as pd
+
+from spectro_app.plugins.uvvis.plugin import UvVisPlugin
+
+
+def test_helios_csv_parsing(tmp_path):
+    helios_csv = """Instrument: Helios Gamma
+Mode: Absorbance
+Pathlength: 1 cm
+Sample ID: Sample-001
+Reference ID: Blank-A
+
+Wavelength (nm);Absorbance
+200;0,123
+201;0,456
+"""
+    path = tmp_path / "sample_helios.csv"
+    path.write_text(helios_csv, encoding="utf-8")
+
+    plugin = UvVisPlugin()
+    spectra = plugin.load([str(path)])
+
+    assert len(spectra) == 1
+    spec = spectra[0]
+    assert np.allclose(spec.wavelength, [200.0, 201.0])
+    assert np.allclose(spec.intensity, [0.123, 0.456])
+    assert spec.meta["instrument"] == "Helios Gamma"
+    assert spec.meta["mode"] == "absorbance"
+    assert spec.meta["pathlength_cm"] == 1.0
+    assert spec.meta["sample_id"] == "Sample-001"
+    assert spec.meta["blank_id"] == "Blank-A"
+    assert spec.meta["role"] == "sample"
+
+
+def test_helios_excel_parsing(tmp_path):
+    rows = [
+        ["Instrument", "Helios Gamma"],
+        ["Mode", "%T"],
+        ["Pathlength", "0.5 cm"],
+        ["Sample ID", "Protein-01"],
+        ["Reference ID", "Buffer"],
+        ["", ""],
+        ["Wavelength (nm)", "Protein-01"],
+        [240, 85.0],
+        [260, 83.0],
+    ]
+    df = pd.DataFrame(rows)
+    path = tmp_path / "helios.xlsx"
+    df.to_excel(path, index=False, header=False)
+
+    plugin = UvVisPlugin()
+    spectra = plugin.load([str(path)])
+
+    assert len(spectra) == 1
+    spec = spectra[0]
+    assert np.allclose(spec.wavelength, [240.0, 260.0])
+    assert np.allclose(spec.intensity, [85.0, 83.0])
+    assert spec.meta["mode"] == "transmittance"
+    assert spec.meta["pathlength_cm"] == 0.5
+    assert spec.meta["blank_id"] == "Buffer"
+    assert spec.meta["sample_id"] == "Protein-01"
+    assert spec.meta["role"] == "sample"
+
+
+def test_generic_csv_with_metadata(tmp_path):
+    generic_csv = """Instrument: CustomSpec 2000
+Mode: Absorbance
+
+wavelength,Sample A,Blank Control
+200,0.100,0.010
+205,0.105,0.011
+"""
+    path = tmp_path / "generic.csv"
+    path.write_text(generic_csv, encoding="utf-8")
+
+    plugin = UvVisPlugin()
+    spectra = plugin.load([str(path)])
+
+    assert len(spectra) == 2
+    samples = {spec.meta["sample_id"]: spec for spec in spectra}
+    sample_spec = samples["Sample A"]
+    blank_spec = samples["Blank Control"]
+
+    assert np.allclose(sample_spec.wavelength, [200.0, 205.0])
+    assert np.allclose(sample_spec.intensity, [0.1, 0.105])
+    assert sample_spec.meta["instrument"] == "CustomSpec 2000"
+    assert sample_spec.meta["mode"] == "absorbance"
+    assert sample_spec.meta["blank_id"] == "Blank Control"
+    assert sample_spec.meta["role"] == "sample"
+
+    assert blank_spec.meta["role"] == "blank"
+    assert blank_spec.meta["blank_id"] == "Blank Control"


### PR DESCRIPTION
## Summary
- add locale sniffing heuristics to the shared IO helpers
- implement a tolerant Helios Gamma reader that populates spectrum metadata
- extend the UV-Vis plugin to load Helios and generic CSV/Excel files and cover them with unit tests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfdbfaeba08324ada62b01a79a1e30