### PR TITLE
Add UV-Vis QC metrics and strengthen recipe validation

### DIFF
--- a/spectro_app/engine/qc.py
+++ b/spectro_app/engine/qc.py
@@ -1,3 +1,313 @@
-def common_qc(specs, params) -> list[dict]:
-    """Compute shared QC metrics. Placeholder."""
-    return []
+"""Quality control helpers shared across spectroscopy plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+from scipy.signal import medfilt
+
+from spectro_app.engine.plugin_api import Spectrum
+
+
+@dataclass
+class SaturationResult:
+    flag: bool
+    minimum: float
+    maximum: float
+    low_fraction: float
+    high_fraction: float
+    limits: Tuple[float, float]
+
+
+@dataclass
+class NoiseResult:
+    rsd: float
+    window: Tuple[float | None, float | None]
+    used_points: int
+
+
+@dataclass
+class JoinResult:
+    count: int
+    max_offset: float
+    mean_offset: float
+    max_overlap_error: float
+    indices: List[int]
+
+
+@dataclass
+class SpikeResult:
+    count: int
+    threshold: float | None
+
+
+@dataclass
+class SmoothingGuardResult:
+    flag: bool
+    requested: int | None
+    spectrum_points: int
+
+
+def _infer_mode(spec: Spectrum) -> str:
+    mode = str(spec.meta.get("mode", "")).strip().lower()
+    if "abs" in mode:
+        return "absorbance"
+    if "%t" in mode or "trans" in mode:
+        return "transmittance"
+    if "%r" in mode or "reflect" in mode:
+        return "reflectance"
+
+    inten = np.asarray(spec.intensity, dtype=float)
+    if not np.any(np.isfinite(inten)):
+        return "unknown"
+    finite = inten[np.isfinite(inten)]
+    if finite.size == 0:
+        return "unknown"
+    max_val = float(np.nanmax(finite))
+    min_val = float(np.nanmin(finite))
+    if max_val > 2.0 and min_val >= 0:
+        return "transmittance"
+    return "absorbance"
+
+
+def _saturation_thresholds(mode: str, intensity: np.ndarray) -> Tuple[float, float]:
+    if mode == "absorbance":
+        return -0.05, 3.0
+    if mode in {"transmittance", "reflectance"}:
+        finite = intensity[np.isfinite(intensity)]
+        if finite.size == 0:
+            return 0.0, 1.0
+        max_val = float(np.nanmax(finite))
+        scale = 100.0 if max_val > 2.0 else 1.0
+        if scale > 10:
+            return 0.5, 99.5
+        return 0.005, 0.995
+    return float(np.nanmin(intensity)), float(np.nanmax(intensity))
+
+
+def compute_saturation(spec: Spectrum) -> SaturationResult:
+    intensity = np.asarray(spec.intensity, dtype=float)
+    mode = _infer_mode(spec)
+    low_limit, high_limit = _saturation_thresholds(mode, intensity)
+    finite = np.isfinite(intensity)
+    count = int(np.count_nonzero(finite))
+    if count == 0:
+        return SaturationResult(False, float("nan"), float("nan"), 0.0, 0.0, (low_limit, high_limit))
+
+    high_hits = np.logical_and(finite, intensity >= high_limit)
+    low_hits = np.logical_and(finite, intensity <= low_limit)
+    high_fraction = float(np.count_nonzero(high_hits)) / count if count else 0.0
+    low_fraction = float(np.count_nonzero(low_hits)) / count if count else 0.0
+    flag = bool(high_fraction > 0 or low_fraction > 0)
+    return SaturationResult(
+        flag=flag,
+        minimum=float(np.nanmin(intensity)),
+        maximum=float(np.nanmax(intensity)),
+        low_fraction=low_fraction,
+        high_fraction=high_fraction,
+        limits=(low_limit, high_limit),
+    )
+
+
+def compute_quiet_window_noise(
+    spec: Spectrum,
+    quiet_window: Dict[str, float] | None,
+) -> NoiseResult:
+    wl = np.asarray(spec.wavelength, dtype=float)
+    intensity = np.asarray(spec.intensity, dtype=float)
+
+    mask = np.isfinite(wl) & np.isfinite(intensity)
+    if quiet_window:
+        q_min = quiet_window.get("min")
+        q_max = quiet_window.get("max")
+    else:
+        q_min = float(wl[np.isfinite(wl)].min()) if np.any(np.isfinite(wl)) else None
+        q_max = None
+
+    if q_min is not None:
+        mask &= wl >= float(q_min)
+    if quiet_window and quiet_window.get("max") is not None:
+        q_max = float(quiet_window["max"])
+        mask &= wl <= q_max
+
+    if mask.sum() < 3:
+        return NoiseResult(rsd=float("nan"), window=(q_min, q_max), used_points=int(mask.sum()))
+
+    window_values = intensity[mask]
+    denominator = float(np.nanmean(np.abs(window_values)))
+    if not np.isfinite(denominator) or abs(denominator) < 1e-12:
+        rsd = float("nan")
+    else:
+        rsd = float(np.nanstd(window_values, ddof=1) / denominator * 100.0)
+
+    return NoiseResult(rsd=rsd, window=(q_min, q_max), used_points=int(mask.sum()))
+
+
+def compute_join_diagnostics(
+    spec: Spectrum,
+    join_cfg: Dict[str, Any] | None,
+) -> JoinResult:
+    from spectro_app.plugins.uvvis import pipeline
+
+    join_cfg = join_cfg or {}
+    if not join_cfg.get("enabled"):
+        return JoinResult(count=0, max_offset=0.0, mean_offset=0.0, max_overlap_error=0.0, indices=[])
+
+    window = int(join_cfg.get("window", 10))
+    if window < 1:
+        window = 1
+
+    y = np.asarray(spec.intensity, dtype=float)
+    joins = pipeline.detect_joins(
+        spec.wavelength,
+        y,
+        threshold=join_cfg.get("threshold"),
+        window=window,
+    )
+    if not joins:
+        return JoinResult(count=0, max_offset=0.0, mean_offset=0.0, max_overlap_error=0.0, indices=[])
+
+    offsets: List[float] = []
+    overlap_errors: List[float] = []
+    for join_idx in joins:
+        left = y[max(0, join_idx - window) : join_idx]
+        right = y[join_idx : min(y.size, join_idx + window)]
+        if left.size == 0 or right.size == 0:
+            continue
+        left_mean = float(np.nanmean(left))
+        right_mean = float(np.nanmean(right))
+        offsets.append(right_mean - left_mean)
+        overlap_len = min(left.size, right.size)
+        if overlap_len:
+            left_tail = left[-overlap_len:]
+            right_head = right[:overlap_len]
+            overlap_errors.append(float(np.nanmean(np.abs(right_head - left_tail))))
+
+    if not offsets:
+        return JoinResult(count=len(joins), max_offset=0.0, mean_offset=0.0, max_overlap_error=0.0, indices=list(joins))
+
+    max_offset = float(np.nanmax(np.abs(offsets))) if offsets else 0.0
+    mean_offset = float(np.nanmean(offsets)) if offsets else 0.0
+    max_overlap_error = float(np.nanmax(overlap_errors)) if overlap_errors else 0.0
+    return JoinResult(
+        count=len(joins),
+        max_offset=max_offset,
+        mean_offset=mean_offset,
+        max_overlap_error=max_overlap_error,
+        indices=list(joins),
+    )
+
+
+def count_spikes(spec: Spectrum, despike_cfg: Dict[str, Any] | None) -> SpikeResult:
+    y = np.asarray(spec.intensity, dtype=float)
+    if y.size < 3:
+        return SpikeResult(count=0, threshold=None)
+
+    despike_cfg = despike_cfg or {}
+    window = int(despike_cfg.get("window", 5))
+    if window % 2 == 0:
+        window += 1
+    if window < 3:
+        window = 3
+    if window > y.size:
+        window = y.size if y.size % 2 else y.size - 1
+    if window < 3:
+        return SpikeResult(count=0, threshold=None)
+
+    baseline = medfilt(y, kernel_size=window)
+    residual = y - baseline
+    median = np.nanmedian(residual)
+    mad = np.nanmedian(np.abs(residual - median))
+    zscore = float(despike_cfg.get("zscore", 5.0))
+    if np.isfinite(mad) and mad > 0:
+        threshold = float(zscore) * 1.4826 * mad
+    else:
+        std = np.nanstd(residual)
+        if not np.isfinite(std) or std == 0:
+            return SpikeResult(count=0, threshold=None)
+        threshold = float(zscore) * std
+    mask = np.abs(residual) > threshold
+    count = int(np.count_nonzero(mask))
+    return SpikeResult(count=count, threshold=threshold)
+
+
+def smoothing_guard(spec: Spectrum, smoothing_cfg: Dict[str, Any] | None) -> SmoothingGuardResult:
+    smoothing_cfg = smoothing_cfg or {}
+    if not smoothing_cfg.get("enabled"):
+        return SmoothingGuardResult(flag=False, requested=None, spectrum_points=spec.intensity.size)
+
+    requested = int(smoothing_cfg.get("window", 5))
+    spectrum_points = int(np.asarray(spec.intensity).size)
+    flag = requested >= max(9, spectrum_points // 2)
+    if requested <= 0:
+        flag = True
+    return SmoothingGuardResult(flag=flag, requested=requested, spectrum_points=spectrum_points)
+
+
+def summarise_uvvis_metrics(metrics: Dict[str, Any]) -> str:
+    parts: List[str] = []
+    saturation: SaturationResult = metrics["saturation"]
+    noise: NoiseResult = metrics["noise"]
+    join: JoinResult = metrics["join"]
+    spikes: SpikeResult = metrics["spikes"]
+    smoothing: SmoothingGuardResult = metrics["smoothing"]
+
+    if saturation.flag:
+        parts.append("Saturation detected")
+    parts.append(f"Noise RSD {noise.rsd:.2f}%" if np.isfinite(noise.rsd) else "Noise RSD n/a")
+    if join.count:
+        parts.append(f"Joins {join.count} (max offset {join.max_offset:.3g})")
+    if spikes.count:
+        parts.append(f"Spikes {spikes.count}")
+    if smoothing.flag:
+        parts.append("Smoothing guard")
+    return "; ".join(parts)
+
+
+def compute_uvvis_qc(spec: Spectrum, recipe: Dict[str, Any]) -> Dict[str, Any]:
+    qc_cfg = recipe.get("qc", {})
+    saturation = compute_saturation(spec)
+    noise = compute_quiet_window_noise(spec, qc_cfg.get("quiet_window"))
+    join = compute_join_diagnostics(spec, recipe.get("join"))
+    spikes = count_spikes(spec, recipe.get("despike"))
+    smoothing = smoothing_guard(spec, recipe.get("smoothing"))
+
+    flags: List[str] = []
+    noise_limit = float(qc_cfg.get("noise_rsd_limit", 5.0))
+    join_limit = float(qc_cfg.get("join_offset_limit", recipe.get("join", {}).get("threshold", 0.0) or 0.5))
+    spike_limit = int(qc_cfg.get("spike_limit", 0))
+
+    if saturation.flag:
+        flags.append("saturation")
+    if np.isfinite(noise.rsd) and noise.rsd > noise_limit:
+        flags.append("noise")
+    if join.count and abs(join.max_offset) > join_limit:
+        flags.append("join_offset")
+    if spikes.count > spike_limit:
+        flags.append("spikes")
+    if smoothing.flag:
+        flags.append("smoothing_guard")
+
+    summary = summarise_uvvis_metrics(
+        {
+            "saturation": saturation,
+            "noise": noise,
+            "join": join,
+            "spikes": spikes,
+            "smoothing": smoothing,
+        }
+    )
+
+    return {
+        "mode": _infer_mode(spec),
+        "saturation": saturation,
+        "noise": noise,
+        "join": join,
+        "spikes": spikes,
+        "smoothing": smoothing,
+        "flags": flags,
+        "summary": summary,
+    }
+

--- a/spectro_app/engine/recipe_model.py
+++ b/spectro_app/engine/recipe_model.py
@@ -9,10 +9,32 @@ class Recipe:
 
     def validate(self) -> list[str]:
         errs = []
-        # Example validation
-        s = self.params.get("smoothing", {})
-        win = s.get("window", 15)
-        poly = s.get("polyorder", 3)
-        if win and win <= poly*2:
-            errs.append("Savitzky–Golay window must be > 2*polyorder")
+        smoothing = self.params.get("smoothing", {})
+        if smoothing.get("enabled"):
+            window = int(smoothing.get("window", 15))
+            poly = int(smoothing.get("polyorder", 3))
+            if window % 2 == 0:
+                errs.append("Savitzky–Golay window must be odd")
+            if window <= poly:
+                errs.append("Savitzky–Golay window must exceed polynomial order")
+            if window <= poly * 2:
+                errs.append("Savitzky–Golay window must be > 2*polyorder")
+            if window < 3:
+                errs.append("Savitzky–Golay window must be at least 3 points")
+
+        join_cfg = self.params.get("join", {})
+        if join_cfg.get("enabled"):
+            window = int(join_cfg.get("window", 0))
+            if window <= 0:
+                errs.append("Join correction window must be positive")
+            threshold = join_cfg.get("threshold")
+            if threshold is not None and float(threshold) <= 0:
+                errs.append("Join detection threshold must be positive")
+
+        blank_cfg = self.params.get("blank", {})
+        subtract = blank_cfg.get("subtract", blank_cfg.get("enabled", False))
+        require_blank = blank_cfg.get("require", subtract)
+        fallback = blank_cfg.get("default") or blank_cfg.get("fallback")
+        if subtract and not require_blank and not fallback:
+            errs.append("Blank subtraction allows missing blanks but provides no fallback/default blank")
         return errs

--- a/spectro_app/tests/test_recipe_validation.py
+++ b/spectro_app/tests/test_recipe_validation.py
@@ -1,5 +1,29 @@
 from spectro_app.engine.recipe_model import Recipe
 
-def test_recipe_validation():
-    r = Recipe(params={"smoothing": {"window": 15, "polyorder": 3}})
-    assert r.validate() == []
+
+def test_recipe_validation_passes_for_reasonable_recipe():
+    params = {
+        "smoothing": {"enabled": True, "window": 15, "polyorder": 3},
+        "join": {"enabled": True, "window": 5, "threshold": 0.5},
+        "blank": {"subtract": True, "require": True},
+    }
+    assert Recipe(params=params).validate() == []
+
+
+def test_recipe_validation_flags_join_and_smoothing_issues():
+    params = {
+        "smoothing": {"enabled": True, "window": 4, "polyorder": 3},
+        "join": {"enabled": True, "window": 0, "threshold": -1},
+    }
+    errs = Recipe(params=params).validate()
+    assert "Savitzky–Golay window must be odd" in errs
+    assert "Join correction window must be positive" in errs
+    assert "Join detection threshold must be positive" in errs
+
+
+def test_recipe_validation_requires_blank_fallback_when_optional():
+    params = {
+        "blank": {"subtract": True, "require": False},
+    }
+    errs = Recipe(params=params).validate()
+    assert "fallback" in errs[0].lower()

--- a/spectro_app/tests/test_uvvis_qc.py
+++ b/spectro_app/tests/test_uvvis_qc.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from spectro_app.engine.plugin_api import Spectrum
+from spectro_app.plugins.uvvis.plugin import UvVisPlugin
+
+
+def test_uvvis_analyze_produces_qc_metrics():
+    wl = np.linspace(400, 500, 21)
+    intensity = np.linspace(0, 100, wl.size)
+    intensity[:5] += np.array([0.0, 0.5, -0.3, 0.4, -0.2])
+    intensity[10:] += 50.0
+    intensity[12] += 75.0  # spike
+
+    spec = Spectrum(
+        wavelength=wl,
+        intensity=intensity,
+        meta={"sample_id": "S1", "role": "sample", "mode": "transmittance"},
+    )
+
+    recipe = {
+        "qc": {
+            "quiet_window": {"min": 400.0, "max": 420.0},
+            "noise_rsd_limit": 1.0,
+            "spike_limit": 0,
+            "join_offset_limit": 100.0,
+        },
+        "join": {"enabled": True, "window": 2, "threshold": 20.0},
+        "despike": {"window": 5, "zscore": 3.0},
+        "smoothing": {"enabled": True, "window": 7, "polyorder": 2},
+    }
+
+    _, qc_rows = UvVisPlugin().analyze([spec], recipe)
+    assert len(qc_rows) == 1
+    row = qc_rows[0]
+
+    assert row["saturation_flag"] is True
+    assert row["spike_count"] >= 1
+    assert row["join_count"] >= 1
+    assert np.isfinite(row["noise_rsd"]) and row["noise_rsd"] >= 0
+    assert "saturation" in row["flags"]
+    assert "Spikes" in row["summary"]
+    assert row["noise_window"] == (400.0, 420.0)


### PR DESCRIPTION
## Summary
- add reusable UV-Vis QC helpers for saturation, noise, join, spike, and smoothing guard metrics and surface them in the plugin analysis output
- extend recipe validation to guard join, blank, and smoothing configuration edges
- cover QC aggregation and recipe validation behaviour with new unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfe24e66508324a858be986d90ee95