### PR TITLE
Add UV-Vis feature extraction and export workflow

### DIFF
--- a/spectro_app/engine/excel_writer.py
+++ b/spectro_app/engine/excel_writer.py
@@ -1,9 +1,159 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence
+
+import numpy as np
+from openpyxl import Workbook
+
+from spectro_app.engine.plugin_api import Spectrum
+
+
+def _ensure_parent(path: Path) -> None:
+    if not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _clean_value(value: Any) -> Any:
+    if isinstance(value, (np.floating, np.integer)):
+        value = float(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return json.dumps([_clean_value(v) for v in value])
+    if isinstance(value, dict):
+        return json.dumps({str(k): _clean_value(v) for k, v in value.items()})
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _flatten_dict(data: Dict[str, Any], prefix: str = "") -> Dict[str, Any]:
+    flat: Dict[str, Any] = {}
+    for key, value in data.items():
+        safe_key = str(key).replace(" ", "_").replace("/", "_")
+        new_key = f"{prefix}{safe_key}" if not prefix else f"{prefix}.{safe_key}"
+        if isinstance(value, dict):
+            flat.update(_flatten_dict(value, new_key))
+        elif isinstance(value, np.ndarray):
+            flat[new_key] = json.dumps(_clean_value(value.tolist()))
+        elif isinstance(value, (list, tuple)):
+            if value and all(isinstance(item, dict) for item in value):
+                flat[new_key] = json.dumps([_clean_value(item) for item in value])
+            else:
+                flat[new_key] = json.dumps([_clean_value(item) for item in value])
+        else:
+            flat[new_key] = _clean_value(value)
+    return flat
+
+
+def _processed_rows(processed: Sequence[Spectrum]) -> List[List[Any]]:
+    rows: List[List[Any]] = []
+    for idx, spec in enumerate(processed):
+        wl = np.asarray(spec.wavelength, dtype=float)
+        intensity = np.asarray(spec.intensity, dtype=float)
+        meta = spec.meta or {}
+        sample_id = (
+            meta.get("sample_id")
+            or meta.get("channel")
+            or meta.get("blank_id")
+            or f"spec_{idx}"
+        )
+        role = meta.get("role", "sample")
+        mode = meta.get("mode")
+        base_channel_name = meta.get("channel_label", "processed")
+        for wl_val, inten_val in zip(wl, intensity):
+            rows.append([
+                idx,
+                sample_id,
+                role,
+                mode,
+                base_channel_name,
+                _clean_value(wl_val),
+                _clean_value(inten_val),
+            ])
+        extra_channels = meta.get("channels") or {}
+        for name, channel in extra_channels.items():
+            arr = np.asarray(channel, dtype=float)
+            if arr.shape != wl.shape:
+                continue
+            for wl_val, inten_val in zip(wl, arr):
+                rows.append([
+                    idx,
+                    sample_id,
+                    role,
+                    mode,
+                    name,
+                    _clean_value(wl_val),
+                    _clean_value(inten_val),
+                ])
+    return rows
+
+
+def _metadata_rows(processed: Sequence[Spectrum]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for idx, spec in enumerate(processed):
+        meta = dict(spec.meta or {})
+        meta.pop("channels", None)
+        flat = _flatten_dict(meta)
+        flat["spectrum_index"] = idx
+        rows.append(flat)
+    return rows
+
+
+def _qc_rows(qc_table: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    output: List[Dict[str, Any]] = []
+    for row in qc_table:
+        output.append(_flatten_dict(dict(row)))
+    return output
+
+
+def _write_dict_rows(ws, rows: List[Dict[str, Any]]):
+    if not rows:
+        return
+    headers = sorted({key for row in rows for key in row.keys()})
+    ws.append(headers)
+    for row in rows:
+        ws.append([_clean_value(row.get(header)) for header in headers])
+
+
 def write_workbook(out_path: str, processed, qc_table, audit, figures):
-    """Placeholder: Implement openpyxl-based export here."""
-    # For scaffold only, just write a tiny text file indicating where Excel would go
-    with open(out_path, "w", encoding="utf-8") as f:
-        f.write("Workbook would be written here.\n")
-        f.write(f"Processed spectra: {len(processed)}\n")
-        f.write(f"QC rows: {len(qc_table)}\n")
-        f.write("\nAudit:\n" + "\n".join(audit))
-    return out_path
+    workbook_path = Path(out_path)
+    _ensure_parent(workbook_path)
+
+    wb = Workbook()
+    ws_processed = wb.active
+    ws_processed.title = "Processed_Spectra"
+    ws_processed.append([
+        "spectrum_index",
+        "sample_id",
+        "role",
+        "mode",
+        "channel",
+        "wavelength",
+        "value",
+    ])
+    for row in _processed_rows(processed):
+        ws_processed.append(row)
+
+    ws_metadata = wb.create_sheet("Metadata")
+    _write_dict_rows(ws_metadata, _metadata_rows(processed))
+
+    ws_qc = wb.create_sheet("QC_Flags")
+    _write_dict_rows(ws_qc, _qc_rows(qc_table))
+
+    ws_calibration = wb.create_sheet("Calibration")
+    ws_calibration.append(["Section", "Details"])
+    ws_calibration.append(["Status", "No calibration performed"])
+
+    ws_audit = wb.create_sheet("Audit_Log")
+    ws_audit.append(["Index", "Entry"])
+    for idx, entry in enumerate(audit or [], start=1):
+        ws_audit.append([idx, _clean_value(entry)])
+
+    wb.save(workbook_path)
+    return str(workbook_path)

--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -1,0 +1,94 @@
+import numpy as np
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+from spectro_app.engine.plugin_api import Spectrum
+from spectro_app.plugins.uvvis.plugin import UvVisPlugin
+
+
+def _mock_spectrum():
+    wl = np.linspace(220.0, 320.0, 401)
+    peak1 = 1.2 * np.exp(-0.5 * ((wl - 260.0) / 4.0) ** 2)
+    peak2 = 0.8 * np.exp(-0.5 * ((wl - 280.0) / 5.0) ** 2)
+    baseline = 0.05 * (wl - wl.min()) / (wl.max() - wl.min())
+    intensity = peak1 + peak2 + baseline
+    return Spectrum(
+        wavelength=wl,
+        intensity=intensity,
+        meta={"sample_id": "Sample-1", "role": "sample", "mode": "absorbance"},
+    )
+
+
+def test_uvvis_analyze_extracts_features():
+    plugin = UvVisPlugin()
+    spec = _mock_spectrum()
+    recipe = {
+        "features": {
+            "integrals": [
+                {"name": "Area_250_280", "min": 250.0, "max": 280.0},
+            ],
+        }
+    }
+
+    processed, qc_rows = plugin.analyze([spec], recipe)
+
+    assert len(processed) == 1
+    enriched = processed[0]
+    features = enriched.meta.get("features")
+    assert features, "features should be captured in spectrum metadata"
+
+    ratios = features.get("band_ratios", {})
+    assert "A260_A280" in ratios
+    assert np.isfinite(ratios["A260_A280"]["value"])
+
+    integrals = features.get("integrals", {})
+    assert "Area_250_280" in integrals
+    assert integrals["Area_250_280"] > 0
+
+    peaks = features.get("peaks", [])
+    assert peaks and peaks[0]["wavelength"]
+
+    channels = enriched.meta.get("channels", {})
+    assert "first_derivative" in channels
+    assert channels["first_derivative"].shape == enriched.wavelength.shape
+
+    assert len(qc_rows) == 1
+    qc_entry = qc_rows[0]
+    assert "band_ratios" in qc_entry
+    assert "integrals" in qc_entry
+
+
+def test_uvvis_export_creates_workbook_with_derivatives(tmp_path):
+    plugin = UvVisPlugin()
+    spec = _mock_spectrum()
+    recipe = {"export": {"path": str(tmp_path / "uvvis_batch.xlsx")}}
+
+    processed, qc_rows = plugin.analyze([spec], recipe)
+    result = plugin.export(processed, qc_rows, recipe)
+
+    workbook_path = Path(recipe["export"]["path"])
+    assert workbook_path.exists(), "Workbook should be written to disk"
+
+    wb = load_workbook(workbook_path)
+    expected_sheets = {"Processed_Spectra", "Metadata", "QC_Flags", "Calibration", "Audit_Log"}
+    assert expected_sheets.issubset(set(wb.sheetnames))
+
+    ws_processed = wb["Processed_Spectra"]
+    header = [cell.value for cell in next(ws_processed.iter_rows(min_row=1, max_row=1))]
+    assert "channel" in header
+    channel_idx = header.index("channel")
+    channels = {row[channel_idx] for row in ws_processed.iter_rows(min_row=2, values_only=True)}
+    assert "first_derivative" in channels
+    assert "second_derivative" in channels
+
+    ws_metadata = wb["Metadata"]
+    metadata_header = [cell.value for cell in next(ws_metadata.iter_rows(min_row=1, max_row=1))]
+    assert any(str(value).startswith("features.band_ratios") for value in metadata_header)
+
+    ws_qc = wb["QC_Flags"]
+    qc_header = [cell.value for cell in next(ws_qc.iter_rows(min_row=1, max_row=1))]
+    assert any("band_ratios" in str(value) for value in qc_header)
+
+    assert result.figures, "Export should include generated plots"
+    assert any("Workbook written" in entry for entry in result.audit)


### PR DESCRIPTION
## Summary
- implement UV-Vis feature extraction including peak metrics, band ratios, integrals, and derivatives for downstream export
- write Excel workbooks with processed spectra, metadata, QC metrics, calibration stub, and audit log entries
- add tests to cover UV-Vis feature extraction and export workflow, including derivative channels and generated plots

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dfe443dd0c8324aca15c5c3f4fb107