### PR TITLE
Support manifest metadata in UV-Vis loader

### DIFF
--- a/spectro_app/featureList.md
+++ b/spectro_app/featureList.md
@@ -19,6 +19,11 @@ Input & ingestion
 Drag-and-drop files/folders; file queue with badges (technique, A/%T, blank/sample).
 
 Manifest CSV for sample↔blank mapping, groupings (dose/site), replicate IDs.
+  - Columns (case-insensitive): `file` (optional; basename or path), `channel`/`column` (optional; raw trace label),
+    `sample_id` (final label), `blank_id`, `replicate`/`replicate_id`, `group`/`group_id`, `role`, `notes`.
+  - Rows without `file` act as defaults; matching prefers file+channel, then file+sample, then global fallbacks.
+  - Channel match enables renaming (e.g., column `A1` → manifest `sample_id` "Dose 1"); blanks can be tagged via `role=blank`.
+  - Parsed fields are merged into spectrum metadata before `Spectrum` creation so downstream blanking/replicate logic sees them.
 
 Tolerant parsers (decimal comma/dot, delimiters, header variants).
 

--- a/spectro_app/tests/test_io_uvvis.py
+++ b/spectro_app/tests/test_io_uvvis.py
@@ -91,3 +91,44 @@ wavelength,Sample A,Blank Control
 
     assert blank_spec.meta["role"] == "blank"
     assert blank_spec.meta["blank_id"] == "Blank Control"
+
+
+def test_manifest_metadata_enrichment(tmp_path):
+    generic_csv = """wavelength,Sample A,Sample B,Blank Control
+200,0.100,0.200,0.010
+205,0.105,0.205,0.011
+"""
+    data_path = tmp_path / "generic.csv"
+    data_path.write_text(generic_csv, encoding="utf-8")
+
+    manifest_csv = """file,channel,sample_id,blank_id,replicate,group,role
+generic.csv,Sample A,Treated-A,Blank-01,rep-1,Dose-Low,
+generic.csv,Sample B,Treated-B,Blank-01,rep-2,Dose-Low,
+generic.csv,Blank Control,Blank-01,,ref-blank,QC,blank
+"""
+    manifest_path = tmp_path / "manifest.csv"
+    manifest_path.write_text(manifest_csv, encoding="utf-8")
+
+    plugin = UvVisPlugin()
+    spectra = plugin.load([str(data_path), str(manifest_path)])
+
+    assert len(spectra) == 3
+
+    by_id = {spec.meta["sample_id"]: spec for spec in spectra}
+    sample_a = by_id["Treated-A"]
+    sample_b = by_id["Treated-B"]
+    blank_spec = by_id["Blank-01"]
+
+    assert sample_a.meta["blank_id"] == "Blank-01"
+    assert sample_a.meta["replicate_id"] == "rep-1"
+    assert sample_a.meta["group_id"] == "Dose-Low"
+    assert sample_a.meta["role"] == "sample"
+
+    assert sample_b.meta["blank_id"] == "Blank-01"
+    assert sample_b.meta["replicate_id"] == "rep-2"
+    assert sample_b.meta["group_id"] == "Dose-Low"
+
+    assert blank_spec.meta["role"] == "blank"
+    assert blank_spec.meta["blank_id"] == "Blank-01"
+    assert blank_spec.meta["replicate_id"] == "ref-blank"
+    assert blank_spec.meta["group_id"] == "QC"


### PR DESCRIPTION
## Summary
- detect optional manifest CSVs during UV-Vis ingestion and merge parsed assignments (blank/sample roles, replicate/group IDs) into spectrum metadata
- document the manifest column conventions so ingestion matches the declared spec
- add a regression test covering manifest-driven metadata enrichment for sample and blank traces

## Testing
- pytest spectro_app/tests/test_io_uvvis.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe84de7d88324bf444b52d913ec37