### PR TITLE
Enforce UV-Vis blank gating with audit metadata

### DIFF
--- a/spectro_app/plugins/uvvis/pipeline.py
+++ b/spectro_app/plugins/uvvis/pipeline.py
@@ -88,8 +88,24 @@ def coerce_domain(spec: Spectrum, domain: Dict[str, float] | None) -> Spectrum:
     return Spectrum(wavelength=wl, intensity=inten, meta=dict(spec.meta))
 
 
-def subtract_blank(sample: Spectrum, blank: Spectrum) -> Spectrum:
-    """Subtract a blank from the sample after verifying domain overlap."""
+def subtract_blank(
+    sample: Spectrum,
+    blank: Spectrum,
+    *,
+    audit: Dict[str, object] | None = None,
+) -> Spectrum:
+    """Subtract a blank from the sample after verifying domain overlap.
+
+    Parameters
+    ----------
+    sample:
+        Sample spectrum that will have the blank removed.
+    blank:
+        Blank spectrum that should be subtracted from ``sample``.
+    audit:
+        Optional metadata recorded for quality-control auditing. Any supplied
+        fields will be merged with statistics gathered during subtraction.
+    """
 
     sample_wl = np.asarray(sample.wavelength, dtype=float)
     blank_interp = np.interp(
@@ -108,8 +124,20 @@ def subtract_blank(sample: Spectrum, blank: Spectrum) -> Spectrum:
     corrected[valid] = corrected[valid] - blank_interp[valid]
     corrected[~valid] = np.nan
 
+    overlap_points = int(valid.sum())
+    overlap_fraction = float(overlap_points) / float(sample_wl.size)
+    blank_mean = float(np.nanmean(blank_interp[valid])) if overlap_points else float("nan")
+
     meta = dict(sample.meta)
     meta["blank_subtracted"] = True
+    audit_payload: Dict[str, object] = {
+        "overlap_points": overlap_points,
+        "overlap_fraction": overlap_fraction,
+        "blank_mean_intensity": blank_mean,
+    }
+    if audit:
+        audit_payload.update(audit)
+    meta["blank_audit"] = audit_payload
     return Spectrum(wavelength=sample.wavelength.copy(), intensity=corrected, meta=meta)
 
 

--- a/spectro_app/tests/test_pipeline_uvvis.py
+++ b/spectro_app/tests/test_pipeline_uvvis.py
@@ -1,3 +1,6 @@
+from datetime import datetime, timedelta
+from typing import Dict
+
 import numpy as np
 import pytest
 
@@ -37,6 +40,11 @@ def test_subtract_blank_validates_overlap_and_subtracts():
     expected = sample.intensity - np.interp(sample.wavelength, blank.wavelength, blank.intensity)
     assert np.allclose(corrected.intensity[1:], expected[1:])
     assert corrected.meta["blank_subtracted"] is True
+    audit = corrected.meta.get("blank_audit")
+    expected_interp = np.interp(sample.wavelength, blank.wavelength, blank.intensity)
+    assert audit["overlap_points"] == sample.wavelength.size
+    assert audit["overlap_fraction"] == pytest.approx(1.0)
+    assert audit["blank_mean_intensity"] == pytest.approx(np.mean(expected_interp))
 
     far_blank = Spectrum(
         wavelength=np.array([600.0, 610.0]),
@@ -45,6 +53,83 @@ def test_subtract_blank_validates_overlap_and_subtracts():
     )
     with pytest.raises(ValueError):
         pipeline.subtract_blank(sample, far_blank)
+
+
+def _build_simple_spectrum(role: str, wl: np.ndarray, value: float, meta: Dict[str, object]) -> Spectrum:
+    return Spectrum(wavelength=wl, intensity=np.full_like(wl, value, dtype=float), meta={"role": role, **meta})
+
+
+def test_preprocess_blank_pairing_records_audit_metadata():
+    wl = np.linspace(400, 410, 3)
+    blank_time = datetime(2024, 1, 1, 10, 0)
+    sample_time = blank_time + timedelta(minutes=30)
+    blank = _build_simple_spectrum(
+        "blank",
+        wl,
+        0.5,
+        {"blank_id": "B1", "sample_id": "B1", "acquired_datetime": blank_time.isoformat(), "pathlength_cm": 1.0},
+    )
+    sample = _build_simple_spectrum(
+        "sample",
+        wl,
+        1.0,
+        {"sample_id": "S1", "blank_id": "B1", "acquired_datetime": sample_time.isoformat(), "pathlength_cm": 1.0},
+    )
+
+    plugin = UvVisPlugin()
+    recipe = {"blank": {"subtract": True, "max_time_delta_minutes": 120}}
+    processed = plugin.preprocess([blank, sample], recipe)
+    processed_sample = next(spec for spec in processed if spec.meta.get("role") != "blank")
+    audit = processed_sample.meta.get("blank_audit")
+    assert audit["timestamp_delta_minutes"] == pytest.approx(30.0)
+    assert audit["pathlength_delta_cm"] == pytest.approx(0.0)
+    assert audit["blank_id"] == "B1"
+    assert audit["sample_id"] == "S1"
+
+
+def test_preprocess_blank_pairing_rejects_time_gap():
+    wl = np.linspace(400, 410, 3)
+    blank_time = datetime(2024, 1, 1, 8, 0)
+    sample_time = blank_time + timedelta(hours=5)
+    blank = _build_simple_spectrum(
+        "blank",
+        wl,
+        0.5,
+        {"blank_id": "B1", "sample_id": "B1", "acquired_datetime": blank_time.isoformat(), "pathlength_cm": 1.0},
+    )
+    sample = _build_simple_spectrum(
+        "sample",
+        wl,
+        1.0,
+        {"sample_id": "S1", "blank_id": "B1", "acquired_datetime": sample_time.isoformat(), "pathlength_cm": 1.0},
+    )
+
+    plugin = UvVisPlugin()
+    recipe = {"blank": {"subtract": True, "max_time_delta_minutes": 60}}
+    with pytest.raises(ValueError):
+        plugin.preprocess([blank, sample], recipe)
+
+
+def test_preprocess_blank_pairing_rejects_pathlength_mismatch():
+    wl = np.linspace(400, 410, 3)
+    timestamp = datetime(2024, 1, 1, 9, 0).isoformat()
+    blank = _build_simple_spectrum(
+        "blank",
+        wl,
+        0.5,
+        {"blank_id": "B1", "sample_id": "B1", "acquired_datetime": timestamp, "pathlength_cm": 0.5},
+    )
+    sample = _build_simple_spectrum(
+        "sample",
+        wl,
+        1.0,
+        {"sample_id": "S1", "blank_id": "B1", "acquired_datetime": timestamp, "pathlength_cm": 1.0},
+    )
+
+    plugin = UvVisPlugin()
+    recipe = {"blank": {"subtract": True, "pathlength_tolerance_cm": 0.1}}
+    with pytest.raises(ValueError):
+        plugin.preprocess([blank, sample], recipe)
 
 
 def test_baseline_methods_reduce_background():


### PR DESCRIPTION
## Summary
- validate UV-Vis sample/blank pairings using timestamp and pathlength metadata before subtraction and attach audit payloads
- extend UV-Vis blank subtraction helper to capture QC overlap statistics alongside supplied metadata
- add UV-Vis pipeline unit tests that cover accepted and rejected blank pairings under the new gating rules

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py

------
https://chatgpt.com/codex/tasks/task_e_68dfeae3cb908324b39aca47fa513b9c