### PR TITLE
Make UV-Vis blank metadata checks optional

### DIFF
--- a/spectro_app/plugins/uvvis/pipeline.py
+++ b/spectro_app/plugins/uvvis/pipeline.py
@@ -137,7 +137,16 @@ def subtract_blank(
     }
     if audit:
         audit_payload.update(audit)
-    meta["blank_audit"] = audit_payload
+
+    existing_audit = meta.get("blank_audit")
+    if isinstance(existing_audit, dict):
+        merged_audit = dict(existing_audit)
+        for key, value in audit_payload.items():
+            merged_audit.setdefault(key, value)
+    else:
+        merged_audit = audit_payload
+
+    meta["blank_audit"] = merged_audit
     return Spectrum(wavelength=sample.wavelength.copy(), intensity=corrected, meta=meta)
 
 

--- a/spectro_app/tests/test_pipeline_uvvis.py
+++ b/spectro_app/tests/test_pipeline_uvvis.py
@@ -85,6 +85,9 @@ def test_preprocess_blank_pairing_records_audit_metadata():
     assert audit["pathlength_delta_cm"] == pytest.approx(0.0)
     assert audit["blank_id"] == "B1"
     assert audit["sample_id"] == "S1"
+    assert audit["validation_ran"] is True
+    assert audit["validation_enforced"] is True
+    assert audit["validation_violations"] == []
 
 
 def test_preprocess_blank_pairing_rejects_time_gap():
@@ -130,6 +133,55 @@ def test_preprocess_blank_pairing_rejects_pathlength_mismatch():
     recipe = {"blank": {"subtract": True, "pathlength_tolerance_cm": 0.1}}
     with pytest.raises(ValueError):
         plugin.preprocess([blank, sample], recipe)
+
+
+def test_preprocess_blank_pairing_opt_out_logs_violations():
+    wl = np.linspace(400, 410, 3)
+    blank_time = datetime(2024, 1, 1, 8, 0)
+    sample_time = blank_time + timedelta(hours=5)
+    blank = _build_simple_spectrum(
+        "blank",
+        wl,
+        0.5,
+        {
+            "blank_id": "B1",
+            "sample_id": "B1",
+            "acquired_datetime": blank_time.isoformat(),
+            "pathlength_cm": 0.5,
+        },
+    )
+    sample = _build_simple_spectrum(
+        "sample",
+        wl,
+        1.0,
+        {
+            "sample_id": "S1",
+            "blank_id": "B1",
+            "acquired_datetime": sample_time.isoformat(),
+            "pathlength_cm": 1.0,
+        },
+    )
+
+    plugin = UvVisPlugin()
+    recipe = {
+        "blank": {
+            "subtract": True,
+            "max_time_delta_minutes": 60,
+            "pathlength_tolerance_cm": 0.1,
+            "validate_metadata": False,
+        }
+    }
+    processed = plugin.preprocess([blank, sample], recipe)
+    processed_sample = next(spec for spec in processed if spec.meta.get("role") != "blank")
+    audit = processed_sample.meta.get("blank_audit")
+
+    assert processed_sample.meta.get("blank_subtracted") is True
+    assert audit["validation_ran"] is True
+    assert audit["validation_enforced"] is False
+    violations = audit["validation_violations"]
+    assert {v["type"] for v in violations} == {"timestamp_gap", "pathlength_mismatch"}
+    assert any(v["observed_minutes"] > 60 for v in violations if v["type"] == "timestamp_gap")
+    assert any(v["observed_delta_cm"] > 0.1 for v in violations if v["type"] == "pathlength_mismatch")
 
 
 def test_baseline_methods_reduce_background():


### PR DESCRIPTION
## Summary
- add a blank recipe flag to control UV-Vis metadata enforcement while still logging violations in the audit payload
- preserve existing blank audit fields when merging subtraction results and record validation metadata
- extend UV-Vis pipeline tests to cover strict failures and opt-out auditing scenarios

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py

------
https://chatgpt.com/codex/tasks/task_e_68dfeebdff488324b66f56cac550c23c