### PR TITLE
Preserve UV-Vis joins during despiking

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -645,6 +645,7 @@ class UvVisPlugin(SpectroscopyPlugin):
         for spec in specs:
             coerced = pipeline.coerce_domain(spec, domain_cfg)
             processed = coerced
+            joins: list[int] = []
             if join_cfg.get("enabled"):
                 joins = pipeline.detect_joins(
                     processed.wavelength,
@@ -659,6 +660,7 @@ class UvVisPlugin(SpectroscopyPlugin):
                     processed,
                     zscore=despike_cfg.get("zscore", 5.0),
                     window=despike_cfg.get("window", 5),
+                    join_indices=joins,
                 )
             stage_one.append(processed)
 


### PR DESCRIPTION
## Summary
- add optional join index handling to the UV-Vis despiking helper so spikes are removed per detector segment
- propagate detected join positions from preprocessing into the despiking stage
- add regression tests covering join-aware despiking and join propagation

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py


------
https://chatgpt.com/codex/tasks/task_e_68dff7842e8c8324afc7a30c557eb732