### PR TITLE
Allow UV-Vis preprocessing without enforced blanks

### DIFF
--- a/spectro_app/engine/recipe_model.py
+++ b/spectro_app/engine/recipe_model.py
@@ -35,6 +35,4 @@ class Recipe:
         subtract = blank_cfg.get("subtract", blank_cfg.get("enabled", False))
         require_blank = blank_cfg.get("require", subtract)
         fallback = blank_cfg.get("default") or blank_cfg.get("fallback")
-        if subtract and not require_blank and not fallback:
-            errs.append("Blank subtraction allows missing blanks but provides no fallback/default blank")
         return errs


### PR DESCRIPTION
## Summary
- add a `disable_blank_requirement` helper in the UV-Vis plugin and document the relaxed blank policy
- allow the recipe validator and preprocessing logic to process samples without blanks while recording audit metadata
- extend the UV-Vis pipeline tests to cover helper usage and non-subtractive audit capture

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py

------
https://chatgpt.com/codex/tasks/task_e_68dff8b57a848324b2794da80dbe5d92