### PR TITLE
Add UV-Vis drift QC metrics and validation

### DIFF
--- a/spectro_app/tests/test_recipe_validation.py
+++ b/spectro_app/tests/test_recipe_validation.py
@@ -27,3 +27,20 @@ def test_recipe_validation_requires_blank_fallback_when_optional():
     }
     errs = Recipe(params=params).validate()
     assert "fallback" in errs[0].lower()
+
+
+def test_recipe_validation_flags_invalid_drift_limits():
+    params = {
+        "qc": {
+            "drift": {
+                "enabled": True,
+                "window": {"min": 300, "max": 200},
+                "max_slope_per_hour": -1,
+                "max_delta": "not-a-number",
+            }
+        }
+    }
+    errs = Recipe(params=params).validate()
+    assert any("Drift window" in err for err in errs)
+    assert any("slope limit" in err for err in errs)
+    assert any("delta limit" in err for err in errs)

--- a/spectro_app/tests/test_uvvis_qc.py
+++ b/spectro_app/tests/test_uvvis_qc.py
@@ -1,4 +1,7 @@
+from datetime import datetime, timedelta
+
 import numpy as np
+import pytest
 
 from spectro_app.engine.plugin_api import Spectrum
 from spectro_app.plugins.uvvis.plugin import UvVisPlugin
@@ -40,3 +43,69 @@ def test_uvvis_analyze_produces_qc_metrics():
     assert "saturation" in row["flags"]
     assert "Spikes" in row["summary"]
     assert row["noise_window"] == (400.0, 420.0)
+
+
+def _make_synthetic_spec(
+    wl: np.ndarray,
+    baseline: float,
+    timestamp: datetime,
+    sample_id: str,
+) -> Spectrum:
+    intensity = np.full_like(wl, baseline, dtype=float)
+    return Spectrum(
+        wavelength=wl,
+        intensity=intensity,
+        meta={"sample_id": sample_id, "role": "sample", "acquired_datetime": timestamp.isoformat()},
+    )
+
+
+def _drift_recipe() -> dict:
+    return {
+        "qc": {
+            "drift": {
+                "enabled": True,
+                "window": {"min": 210.0, "max": 290.0},
+                "max_slope_per_hour": 0.5,
+                "max_delta": 0.6,
+                "max_residual": 0.4,
+            }
+        }
+    }
+
+
+def test_uvvis_qc_drift_stable_batch_not_flagged():
+    wl = np.linspace(200, 300, 51)
+    start = datetime(2024, 1, 1, 8, 0)
+    baselines = [0.5, 0.55, 0.48, 0.52]
+    specs = [
+        _make_synthetic_spec(wl, base, start + timedelta(minutes=idx * 15), f"S{idx}")
+        for idx, base in enumerate(baselines)
+    ]
+    _, qc_rows = UvVisPlugin().analyze(specs, _drift_recipe())
+
+    assert qc_rows
+    assert all(row["drift_available"] for row in qc_rows)
+    assert all(not row["drift_flag"] for row in qc_rows)
+    assert all("drift" not in row["flags"] for row in qc_rows)
+
+
+def test_uvvis_qc_drift_flags_increasing_trend():
+    wl = np.linspace(200, 300, 51)
+    start = datetime(2024, 1, 1, 9, 0)
+    baselines = [0.5, 0.9, 1.3, 1.7]
+    specs = [
+        _make_synthetic_spec(wl, base, start + timedelta(minutes=idx * 15), f"D{idx}")
+        for idx, base in enumerate(baselines)
+    ]
+    _, qc_rows = UvVisPlugin().analyze(specs, _drift_recipe())
+
+    assert qc_rows
+    assert any(row["drift_flag"] for row in qc_rows)
+    assert any("drift" in row["flags"] for row in qc_rows)
+    flagged = [row for row in qc_rows if row["drift_flag"]]
+    assert flagged
+    for row in flagged:
+        assert "slope" in row["drift_reasons"]
+        assert row["drift_slope_per_hour"] is not None
+        assert np.isfinite(row["drift_slope_per_hour"])
+    assert qc_rows[-1]["drift_span_minutes"] == pytest.approx(45.0)


### PR DESCRIPTION
## Summary
- compute UV-Vis drift metrics using acquisition timestamps and configurable baseline windows
- surface drift results and flags in the QC output and expand recipe validation for drift settings
- add tests covering stable versus drifting batches and drift configuration validation

## Testing
- pytest spectro_app/tests/test_uvvis_qc.py spectro_app/tests/test_recipe_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68dffb97e1ac8324977436e2d2189e8d