### PR TITLE
Handle duplicate UV-Vis wavelengths

### DIFF
--- a/spectro_app/plugins/uvvis/pipeline.py
+++ b/spectro_app/plugins/uvvis/pipeline.py
@@ -60,6 +60,12 @@ def coerce_domain(spec: Spectrum, domain: Dict[str, float] | None) -> Spectrum:
     if wl.size == 0:
         raise ValueError("Spectrum does not contain finite wavelength samples")
 
+    unique_wl, inverse, counts = np.unique(wl, return_inverse=True, return_counts=True)
+    aggregated_inten = np.zeros_like(unique_wl, dtype=float)
+    np.add.at(aggregated_inten, inverse, inten)
+    inten = aggregated_inten / counts
+    wl = unique_wl
+
     original_min = float(wl[0])
     original_max = float(wl[-1])
 

--- a/spectro_app/tests/test_pipeline_uvvis.py
+++ b/spectro_app/tests/test_pipeline_uvvis.py
@@ -33,6 +33,37 @@ def test_coerce_domain_interpolates_and_sorts():
     assert domain_meta["output_max_nm"] == pytest.approx(500.0)
 
 
+def test_coerce_domain_averages_duplicate_wavelengths_before_clipping():
+    spec = Spectrum(
+        wavelength=np.array([500.0, 400.0, 500.0, 450.0, 400.0]),
+        intensity=np.array([10.0, 1.0, 30.0, 5.0, 5.0]),
+        meta={},
+    )
+    domain = {"min": 395.0, "max": 505.0}
+    coerced = pipeline.coerce_domain(spec, domain)
+
+    assert np.allclose(coerced.wavelength, np.array([400.0, 450.0, 500.0]))
+    assert np.allclose(coerced.intensity, np.array([3.0, 5.0, 20.0]))
+
+
+def test_coerce_domain_interpolates_from_merged_duplicates():
+    spec = Spectrum(
+        wavelength=np.array([450.0, 450.0, 475.0, 400.0, 400.0]),
+        intensity=np.array([2.0, 4.0, 6.0, 0.0, 1.0]),
+        meta={},
+    )
+    domain = {"min": 400.0, "max": 475.0, "step": 25.0}
+    coerced = pipeline.coerce_domain(spec, domain)
+
+    expected_axis = np.array([400.0, 425.0, 450.0, 475.0])
+    base_wl = np.array([400.0, 450.0, 475.0])
+    base_intensity = np.array([0.5, 3.0, 6.0])
+    expected_intensity = np.interp(expected_axis, base_wl, base_intensity)
+
+    assert np.allclose(coerced.wavelength, expected_axis)
+    assert np.allclose(coerced.intensity, expected_intensity)
+
+
 def test_subtract_blank_validates_overlap_and_subtracts():
     sample = Spectrum(
         wavelength=np.array([400.0, 450.0, 500.0]),


### PR DESCRIPTION
## Summary
- average duplicate wavelength samples within `coerce_domain` prior to clipping or interpolation
- add regression tests covering duplicate wavelengths and merged interpolation behaviour

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py

------
https://chatgpt.com/codex/tasks/task_e_68e12bf584988324b15e7a08cb7cb10a