### PR TITLE
Ensure UV-Vis export workbook includes calibration data

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -2482,21 +2482,6 @@ class UvVisPlugin(SpectroscopyPlugin):
         audit_entries = self._build_audit_entries(specs, qc, recipe, figures)
         workbook_audit = list(audit_entries)
         calibration_results = getattr(self, "_last_calibration_results", None)
-        if output_path:
-            resolved_path = str(output_path)
-            workbook_audit.append(f"Workbook written to {resolved_path}")
-            write_workbook(
-                resolved_path,
-                specs,
-                qc,
-                workbook_audit,
-                figures,
-                calibration_results,
-            )
-            audit_entries = workbook_audit
-        else:
-            audit_entries.append("No workbook path provided; workbook not written.")
-        return BatchResult(processed=specs, qc_table=qc, figures=figures, audit=audit_entries)
         workbook_default = workbook_target if workbook_target else None
         recipe_target = self._coerce_export_path(
             export_cfg.get("recipe_path") or export_cfg.get("recipe_sidecar") or export_cfg.get("recipe"),
@@ -2514,7 +2499,14 @@ class UvVisPlugin(SpectroscopyPlugin):
             if workbook_target:
                 resolved_path = str(workbook_target)
                 workbook_audit.append(f"Workbook written to {resolved_path}")
-                write_workbook(resolved_path, specs, qc, workbook_audit, figures)
+                write_workbook(
+                    resolved_path,
+                    specs,
+                    qc,
+                    workbook_audit,
+                    figures,
+                    calibration_results,
+                )
             else:
                 workbook_audit.append("No workbook path provided; workbook not written.")
 

--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -161,8 +161,21 @@ def test_uvvis_calibration_success(tmp_path):
     wb = load_workbook(workbook_path)
     ws_calibration = wb["Calibration"]
     rows = list(ws_calibration.iter_rows(values_only=True))
-    assert any(row[0] == "Analyte" for row in rows if row and row[0])
-    assert any("Sample-1" in row for row in rows if row)
+    summary_header = rows[0]
+    assert summary_header[:3] == ("Target", "Status", "Slope")
+    analyte_summary = next(row for row in rows if row and row[0] == "Analyte")
+    assert analyte_summary[1] == "ok"
+    assert analyte_summary[2] == pytest.approx(slope, rel=1e-6)
+
+    standards_header = next(row for row in rows if row and "Response (A/cm)" in row)
+    assert standards_header[:3] == ("Sample ID", "Concentration", "Response (A/cm)")
+    std_row = next(row for row in rows if row and row[0] == "Std-1")
+    assert std_row[2] == pytest.approx(intercept + slope * 5.0, rel=1e-6)
+
+    unknowns_header = next(row for row in rows if row and "Predicted Concentration" in row)
+    assert unknowns_header[0] == "Sample ID"
+    sample_row = next(row for row in rows if row and row[0] == "Sample-1")
+    assert sample_row[3] == pytest.approx(7.5, rel=1e-4)
     assert any("Calibration Analyte" in entry for entry in result.audit)
 
 


### PR DESCRIPTION
## Summary
- remove the stray export branch that returned early without writing ancillary artifacts
- thread the captured calibration results into the workbook writer so the calibration sheet can populate
- extend the calibration export regression test to verify Beer–Lambert outputs are included in the Calibration worksheet

## Testing
- pytest spectro_app/tests/test_uvvis_export.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e13272ac548324b81df5c0b986beaf