### PR TITLE
Fix UV-Vis export path handling and add regression coverage

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -2482,21 +2482,6 @@ class UvVisPlugin(SpectroscopyPlugin):
         audit_entries = self._build_audit_entries(specs, qc, recipe, figures)
         workbook_audit = list(audit_entries)
         calibration_results = getattr(self, "_last_calibration_results", None)
-        if output_path:
-            resolved_path = str(output_path)
-            workbook_audit.append(f"Workbook written to {resolved_path}")
-            write_workbook(
-                resolved_path,
-                specs,
-                qc,
-                workbook_audit,
-                figures,
-                calibration_results,
-            )
-            audit_entries = workbook_audit
-        else:
-            audit_entries.append("No workbook path provided; workbook not written.")
-        return BatchResult(processed=specs, qc_table=qc, figures=figures, audit=audit_entries)
         workbook_default = workbook_target if workbook_target else None
         recipe_target = self._coerce_export_path(
             export_cfg.get("recipe_path") or export_cfg.get("recipe_sidecar") or export_cfg.get("recipe"),
@@ -2514,7 +2499,14 @@ class UvVisPlugin(SpectroscopyPlugin):
             if workbook_target:
                 resolved_path = str(workbook_target)
                 workbook_audit.append(f"Workbook written to {resolved_path}")
-                write_workbook(resolved_path, specs, qc, workbook_audit, figures)
+                write_workbook(
+                    resolved_path,
+                    specs,
+                    qc,
+                    workbook_audit,
+                    figures,
+                    calibration_results,
+                )
             else:
                 workbook_audit.append("No workbook path provided; workbook not written.")
 

--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -107,6 +107,35 @@ def test_uvvis_export_creates_workbook_with_derivatives(tmp_path):
     assert any("Workbook written" in entry for entry in result.audit)
 
 
+def test_uvvis_export_with_workbook_path_creates_sidecar_and_pdf(tmp_path):
+    plugin = UvVisPlugin()
+    spec = _mock_spectrum()
+    recipe = {
+        "export": {
+            "path": str(tmp_path / "uvvis_batch.xlsx"),
+            "recipe_sidecar": True,
+            "pdf_report": True,
+        }
+    }
+
+    processed, qc_rows = plugin.analyze([spec], recipe)
+
+    result = plugin.export(processed, qc_rows, recipe)
+
+    workbook_path = tmp_path / "uvvis_batch.xlsx"
+    recipe_sidecar = tmp_path / "uvvis_batch.recipe.json"
+    pdf_report = tmp_path / "uvvis_batch.pdf"
+
+    assert workbook_path.exists()
+    assert recipe_sidecar.exists()
+    assert pdf_report.exists()
+
+    audit_text = "\n".join(result.audit)
+    assert "Workbook written" in audit_text
+    assert "Recipe sidecar written" in audit_text
+    assert "PDF report written" in audit_text
+
+
 def test_uvvis_calibration_success(tmp_path):
     plugin = UvVisPlugin()
     slope = 0.12


### PR DESCRIPTION
## Summary
- remove the stray workbook branch so export uses the computed workbook target and still captures calibration details
- ensure the consolidated export path appends audit messages once and closes figures before returning results
- add a regression test that verifies exporting with a workbook path writes the workbook, recipe sidecar, and PDF

## Testing
- pytest spectro_app/tests/test_uvvis_export.py -k workbook_path -q

------
https://chatgpt.com/codex/tasks/task_e_68e13271c50483249183f9f685168509