### PR TITLE
Record UV-Vis processing stages as exportable channels

### DIFF
--- a/spectro_app/engine/excel_writer.py
+++ b/spectro_app/engine/excel_writer.py
@@ -85,7 +85,11 @@ def _processed_rows(processed: Sequence[Spectrum]) -> List[List[Any]]:
                 _clean_value(inten_val),
             ])
         extra_channels = meta.get("channels") or {}
-        for name, channel in extra_channels.items():
+        stage_order = ["raw", "blanked", "baseline_corrected", "joined", "despiked", "smoothed"]
+        ordered_names = [name for name in stage_order if name in extra_channels]
+        ordered_names.extend(name for name in extra_channels.keys() if name not in ordered_names)
+        for name in ordered_names:
+            channel = extra_channels[name]
             arr = np.asarray(channel, dtype=float)
             if arr.shape != wl.shape:
                 continue

--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -8,6 +8,7 @@ from openpyxl import load_workbook
 
 from spectro_app.engine.plugin_api import Spectrum
 from spectro_app.plugins.uvvis.plugin import UvVisPlugin
+from spectro_app.plugins.uvvis import pipeline
 
 
 def _mock_spectrum():
@@ -105,6 +106,46 @@ def test_uvvis_export_creates_workbook_with_derivatives(tmp_path):
 
     assert result.figures, "Export should include generated plots"
     assert any("Workbook written" in entry for entry in result.audit)
+
+
+def test_uvvis_export_includes_pipeline_stage_channels(tmp_path):
+    plugin = UvVisPlugin()
+    wl = np.linspace(400.0, 460.0, 7)
+    raw_intensity = np.array([1.0, 1.2, 1.1, 3.5, 3.6, 3.7, 3.8])
+    sample = Spectrum(
+        wavelength=wl,
+        intensity=raw_intensity,
+        meta={"sample_id": "StageSample", "role": "sample"},
+    )
+    blank = Spectrum(
+        wavelength=wl,
+        intensity=np.full_like(wl, 0.2, dtype=float),
+        meta={"role": "blank"},
+    )
+
+    coerced = pipeline.coerce_domain(sample, {"min": 400.0, "max": 460.0, "num": 7})
+    joined = pipeline.correct_joins(coerced, [3], window=1)
+    despiked = pipeline.despike_spectrum(joined, zscore=2.0, window=3)
+    blanked = pipeline.subtract_blank(despiked, blank)
+    baseline = pipeline.apply_baseline(blanked, "asls", lam=1e2, p=0.01, niter=10)
+    smoothed = pipeline.smooth_spectrum(baseline, window=5, polyorder=2)
+
+    recipe = {"export": {"path": str(tmp_path / "stage_channels.xlsx")}}
+    plugin.export([smoothed], [{}], recipe)
+
+    workbook_path = Path(recipe["export"]["path"])
+    assert workbook_path.exists()
+    wb = load_workbook(workbook_path)
+    ws_processed = wb["Processed_Spectra"]
+    header = [cell.value for cell in next(ws_processed.iter_rows(min_row=1, max_row=1))]
+    channel_idx = header.index("channel")
+    channels = {
+        row[channel_idx]
+        for row in ws_processed.iter_rows(min_row=2, values_only=True)
+        if row and row[1] == "StageSample"
+    }
+    expected = {"raw", "blanked", "baseline_corrected", "joined", "despiked", "smoothed"}
+    assert expected.issubset(channels)
 
 
 def test_uvvis_calibration_success(tmp_path):


### PR DESCRIPTION
## Summary
- track each UV-Vis preprocessing stage in Spectrum.meta['channels'] and surface them in plots and workbooks
- order stage overlays before other channels for figure rendering and export rows
- add regression coverage to ensure pipeline stages and exports preserve the new channels

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py spectro_app/tests/test_uvvis_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e13273c654832484e6e997b55cffd2