### PR TITLE
Add UV-Vis roughness metrics to QC outputs and exports

### DIFF
--- a/spectro_app/engine/qc.py
+++ b/spectro_app/engine/qc.py
@@ -11,6 +11,15 @@ from scipy.signal import medfilt
 
 from spectro_app.engine.plugin_api import Spectrum
 
+STAGE_CHANNEL_NAMES: Tuple[str, ...] = (
+    "raw",
+    "blanked",
+    "baseline_corrected",
+    "joined",
+    "despiked",
+    "smoothed",
+)
+
 
 @dataclass
 class SaturationResult:
@@ -66,6 +75,20 @@ class DriftResult:
     reasons: List[str]
     batch_reasons: List[str]
     window: Tuple[float | None, float | None]
+
+
+def _mean_abs_first_difference(values: np.ndarray) -> float:
+    arr = np.asarray(values, dtype=float).ravel()
+    if arr.size < 2:
+        return float("nan")
+    diffs = np.diff(arr)
+    if diffs.size == 0:
+        return float("nan")
+    abs_diffs = np.abs(diffs)
+    finite = np.isfinite(abs_diffs)
+    if not np.any(finite):
+        return float("nan")
+    return float(np.nanmean(abs_diffs[finite]))
 
 
 def _infer_mode(spec: Spectrum) -> str:
@@ -483,6 +506,19 @@ def compute_uvvis_qc(
     spikes = count_spikes(spec, recipe.get("despike"))
     smoothing = smoothing_guard(spec, recipe.get("smoothing"))
 
+    processed_roughness = _mean_abs_first_difference(spec.intensity)
+    channel_roughness: Dict[str, float] = {}
+    channels_meta = spec.meta.get("channels") if isinstance(spec.meta, dict) else None
+    if isinstance(channels_meta, dict):
+        for name in STAGE_CHANNEL_NAMES:
+            if name not in channels_meta:
+                continue
+            try:
+                channel_roughness[name] = _mean_abs_first_difference(channels_meta[name])
+            except (TypeError, ValueError):
+                continue
+    roughness_metrics = {"processed": processed_roughness, "channels": channel_roughness}
+
     if drift is None:
         drift_cfg = qc_cfg.get("drift", {}) if qc_cfg else {}
         window_cfg = drift_cfg.get("window") or {}
@@ -543,6 +579,7 @@ def compute_uvvis_qc(
         "spikes": spikes,
         "smoothing": smoothing,
         "drift": drift,
+        "roughness": roughness_metrics,
         "flags": flags,
         "summary": summary,
     }

--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -2194,6 +2194,29 @@ class UvVisPlugin(SpectroscopyPlugin):
             spikes = metrics["spikes"]
             smoothing = metrics["smoothing"]
             drift = metrics["drift"]
+            roughness_metrics = metrics.get("roughness", {})
+            processed_roughness_raw = roughness_metrics.get("processed")
+            try:
+                processed_roughness = float(processed_roughness_raw)
+            except (TypeError, ValueError):
+                processed_roughness = float("nan")
+            channel_roughness_raw = roughness_metrics.get("channels")
+            channel_roughness: Dict[str, float] = {}
+            if isinstance(channel_roughness_raw, dict):
+                for name, value in channel_roughness_raw.items():
+                    try:
+                        channel_roughness[name] = float(value)
+                    except (TypeError, ValueError):
+                        channel_roughness[name] = float("nan")
+            roughness_delta: Dict[str, float] = {}
+            if np.isfinite(processed_roughness):
+                for name, value in channel_roughness.items():
+                    if np.isfinite(value):
+                        roughness_delta[name] = value - processed_roughness
+                    else:
+                        roughness_delta[name] = float("nan")
+            else:
+                roughness_delta = {name: float("nan") for name in channel_roughness}
             wl = np.asarray(spec.wavelength, dtype=float)
             intensity = np.asarray(spec.intensity, dtype=float)
             derivatives = self._compute_derivatives(wl, intensity, derivative_enabled)
@@ -2247,6 +2270,8 @@ class UvVisPlugin(SpectroscopyPlugin):
                 "drift_span_minutes": drift.span_minutes,
                 "drift_timestamp": drift.timestamp.isoformat() if drift.timestamp else None,
                 "drift_window": drift.window,
+                "roughness": {"processed": processed_roughness, "channels": channel_roughness},
+                "roughness_delta": roughness_delta,
                 "flags": metrics["flags"],
                 "summary": metrics["summary"],
                 "band_ratios": band_ratios,

--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -133,7 +133,16 @@ def test_uvvis_export_includes_pipeline_stage_channels(tmp_path):
     smoothed = pipeline.smooth_spectrum(baseline, window=5, polyorder=2)
 
     recipe = {"export": {"path": str(tmp_path / "stage_channels.xlsx")}}
-    plugin.export([smoothed], [{}], recipe)
+    processed, qc_rows = plugin.analyze([smoothed], recipe)
+    assert qc_rows
+    qc_row = qc_rows[0]
+    assert "roughness" in qc_row
+    assert "raw" in qc_row["roughness"]["channels"]
+    assert "smoothed" in qc_row["roughness"]["channels"]
+    assert qc_row["roughness"]["channels"]["smoothed"] <= qc_row["roughness"]["channels"]["raw"]
+    assert qc_row["roughness_delta"]["raw"] > 0.0
+
+    plugin.export(processed, qc_rows, recipe)
 
     workbook_path = Path(recipe["export"]["path"])
     assert workbook_path.exists()
@@ -148,6 +157,22 @@ def test_uvvis_export_includes_pipeline_stage_channels(tmp_path):
     }
     expected = {"raw", "blanked", "baseline_corrected", "joined", "despiked", "smoothed"}
     assert expected.issubset(channels)
+    ws_qc = wb["QC_Flags"]
+    qc_header = [cell.value for cell in next(ws_qc.iter_rows(min_row=1, max_row=1))]
+    assert "roughness.processed" in qc_header
+    assert "roughness.channels.raw" in qc_header
+    assert "roughness.channels.smoothed" in qc_header
+    assert "roughness_delta.raw" in qc_header
+    data_row = next(ws_qc.iter_rows(min_row=2, max_row=2, values_only=True))
+    processed_idx = qc_header.index("roughness.processed")
+    raw_idx = qc_header.index("roughness.channels.raw")
+    smoothed_idx = qc_header.index("roughness.channels.smoothed")
+    raw_delta_idx = qc_header.index("roughness_delta.raw")
+    assert data_row[processed_idx] is not None
+    assert data_row[raw_idx] is not None
+    assert data_row[smoothed_idx] is not None
+    assert data_row[raw_idx] > data_row[smoothed_idx]
+    assert data_row[raw_delta_idx] > 0.0
 def test_uvvis_export_audit_includes_runtime_and_input_hash(tmp_path):
     plugin = UvVisPlugin()
     spec = _mock_spectrum()

--- a/spectro_app/tests/test_uvvis_qc.py
+++ b/spectro_app/tests/test_uvvis_qc.py
@@ -4,7 +4,22 @@ import numpy as np
 import pytest
 
 from spectro_app.engine.plugin_api import Spectrum
+from spectro_app.plugins.uvvis import pipeline
 from spectro_app.plugins.uvvis.plugin import UvVisPlugin
+
+
+def _mean_abs_first_diff(values: np.ndarray) -> float:
+    arr = np.asarray(values, dtype=float).ravel()
+    if arr.size < 2:
+        return float("nan")
+    diffs = np.diff(arr)
+    if diffs.size == 0:
+        return float("nan")
+    abs_diffs = np.abs(diffs)
+    finite = np.isfinite(abs_diffs)
+    if not np.any(finite):
+        return float("nan")
+    return float(np.nanmean(abs_diffs[finite]))
 
 
 def test_uvvis_analyze_produces_qc_metrics():
@@ -43,6 +58,42 @@ def test_uvvis_analyze_produces_qc_metrics():
     assert "saturation" in row["flags"]
     assert "Spikes" in row["summary"]
     assert row["noise_window"] == (400.0, 420.0)
+    assert "roughness" in row
+    assert np.isfinite(row["roughness"]["processed"])
+    assert row["roughness"]["channels"] == {}
+    assert "roughness_delta" in row
+    assert row["roughness_delta"] == {}
+
+
+def test_uvvis_qc_reports_roughness_for_stage_channels():
+    wl = np.linspace(200.0, 260.0, 121)
+    raw_intensity = np.sin(wl / 9.0) + 0.25 * np.sin(wl * 0.9)
+    spec = Spectrum(
+        wavelength=wl,
+        intensity=raw_intensity,
+        meta={"sample_id": "rough", "role": "sample"},
+    )
+    coerced = pipeline.coerce_domain(spec, None)
+    smoothed = pipeline.smooth_spectrum(coerced, window=9, polyorder=3)
+
+    _, qc_rows = UvVisPlugin().analyze([smoothed], {})
+    assert len(qc_rows) == 1
+    row = qc_rows[0]
+
+    processed_expected = _mean_abs_first_diff(smoothed.intensity)
+    raw_expected = _mean_abs_first_diff(smoothed.meta["channels"]["raw"])
+    smoothed_expected = _mean_abs_first_diff(smoothed.meta["channels"]["smoothed"])
+
+    roughness = row["roughness"]
+    assert roughness["processed"] == pytest.approx(processed_expected)
+    assert roughness["channels"]["raw"] == pytest.approx(raw_expected)
+    assert roughness["channels"]["smoothed"] == pytest.approx(smoothed_expected)
+    assert roughness["channels"]["smoothed"] <= roughness["channels"]["raw"]
+
+    delta = row["roughness_delta"]
+    assert delta["raw"] == pytest.approx(raw_expected - processed_expected)
+    assert delta["smoothed"] == pytest.approx(smoothed_expected - processed_expected, abs=1e-9)
+    assert delta["raw"] > 0.0
 
 
 def _make_synthetic_spec(


### PR DESCRIPTION
## Summary
- compute a mean absolute first-difference roughness metric for processed spectra and stage channels in the UV-Vis QC helper
- surface the roughness values and their deltas from `UvVisPlugin.analyze()` so they flow through QC tables and exports
- extend QC and export regression tests to validate roughness reporting and smoothing improvements

## Testing
- pytest spectro_app/tests/test_uvvis_qc.py spectro_app/tests/test_uvvis_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e136fb8f988324bd6f000245876fda