### PR TITLE
Add rolling RSD QC evaluation for UV-Vis spectra

### DIFF
--- a/spectro_app/engine/qc.py
+++ b/spectro_app/engine/qc.py
@@ -30,6 +30,16 @@ class NoiseResult:
 
 
 @dataclass
+class RollingNoiseResult:
+    enabled: bool
+    window_points: int
+    step_points: int
+    windows: int
+    max_rsd: float
+    median_rsd: float
+
+
+@dataclass
 class JoinResult:
     count: int
     max_offset: float
@@ -161,6 +171,73 @@ def compute_quiet_window_noise(
         rsd = float(np.nanstd(window_values, ddof=1) / denominator * 100.0)
 
     return NoiseResult(rsd=rsd, window=(q_min, q_max), used_points=int(mask.sum()))
+
+
+def compute_rolling_rsd(spec: Spectrum, rolling_cfg: Dict[str, Any] | None) -> RollingNoiseResult:
+    rolling_cfg = rolling_cfg or {}
+    window = int(rolling_cfg.get("window", 0) or 0)
+    step = int(rolling_cfg.get("step", 1) or 1)
+
+    if window <= 1 or step <= 0:
+        return RollingNoiseResult(
+            enabled=bool(rolling_cfg),
+            window_points=max(window, 0),
+            step_points=max(step, 1),
+            windows=0,
+            max_rsd=float("nan"),
+            median_rsd=float("nan"),
+        )
+
+    intensity = np.asarray(spec.intensity, dtype=float)
+    finite_mask = np.isfinite(intensity)
+    if not np.any(finite_mask):
+        return RollingNoiseResult(
+            enabled=True,
+            window_points=window,
+            step_points=step,
+            windows=0,
+            max_rsd=float("nan"),
+            median_rsd=float("nan"),
+        )
+
+    rsd_values: List[float] = []
+    total_points = intensity.size
+    for start in range(0, total_points - window + 1, step):
+        window_values = intensity[start : start + window]
+        finite = window_values[np.isfinite(window_values)]
+        if finite.size < 3:
+            continue
+        denominator = float(np.nanmean(np.abs(finite)))
+        if not np.isfinite(denominator) or abs(denominator) < 1e-12:
+            continue
+        if finite.size < 2:
+            continue
+        rsd = float(np.nanstd(finite, ddof=1) / denominator * 100.0)
+        if np.isfinite(rsd):
+            rsd_values.append(rsd)
+
+    if not rsd_values:
+        return RollingNoiseResult(
+            enabled=True,
+            window_points=window,
+            step_points=step,
+            windows=0,
+            max_rsd=float("nan"),
+            median_rsd=float("nan"),
+        )
+
+    rsd_array = np.array(rsd_values, dtype=float)
+    max_rsd = float(np.nanmax(rsd_array)) if rsd_array.size else float("nan")
+    median_rsd = float(np.nanmedian(rsd_array)) if rsd_array.size else float("nan")
+
+    return RollingNoiseResult(
+        enabled=True,
+        window_points=window,
+        step_points=step,
+        windows=len(rsd_values),
+        max_rsd=max_rsd,
+        median_rsd=median_rsd,
+    )
 
 
 def compute_join_diagnostics(
@@ -449,6 +526,7 @@ def summarise_uvvis_metrics(metrics: Dict[str, Any]) -> str:
     parts: List[str] = []
     saturation: SaturationResult = metrics["saturation"]
     noise: NoiseResult = metrics["noise"]
+    rolling: RollingNoiseResult = metrics.get("rolling_noise")
     join: JoinResult = metrics["join"]
     spikes: SpikeResult = metrics["spikes"]
     smoothing: SmoothingGuardResult = metrics["smoothing"]
@@ -457,6 +535,8 @@ def summarise_uvvis_metrics(metrics: Dict[str, Any]) -> str:
     if saturation.flag:
         parts.append("Saturation detected")
     parts.append(f"Noise RSD {noise.rsd:.2f}%" if np.isfinite(noise.rsd) else "Noise RSD n/a")
+    if rolling and rolling.enabled and rolling.windows and np.isfinite(rolling.max_rsd):
+        parts.append(f"Rolling noise max {rolling.max_rsd:.2f}%")
     if join.count:
         parts.append(f"Joins {join.count} (max offset {join.max_offset:.3g})")
     if spikes.count:
@@ -479,6 +559,7 @@ def compute_uvvis_qc(
     qc_cfg = recipe.get("qc", {})
     saturation = compute_saturation(spec)
     noise = compute_quiet_window_noise(spec, qc_cfg.get("quiet_window"))
+    rolling_noise = compute_rolling_rsd(spec, qc_cfg.get("rolling_rsd"))
     join = compute_join_diagnostics(spec, recipe.get("join"))
     spikes = count_spikes(spec, recipe.get("despike"))
     smoothing = smoothing_guard(spec, recipe.get("smoothing"))
@@ -510,11 +591,22 @@ def compute_uvvis_qc(
     noise_limit = float(qc_cfg.get("noise_rsd_limit", 5.0))
     join_limit = float(qc_cfg.get("join_offset_limit", recipe.get("join", {}).get("threshold", 0.0) or 0.5))
     spike_limit = int(qc_cfg.get("spike_limit", 0))
+    rolling_cfg = qc_cfg.get("rolling_rsd") or {}
+    rolling_limit = rolling_cfg.get("limit")
+    rolling_limit_val = float(rolling_limit) if rolling_limit is not None else None
 
     if saturation.flag:
         flags.append("saturation")
     if np.isfinite(noise.rsd) and noise.rsd > noise_limit:
         flags.append("noise")
+    if (
+        rolling_noise.enabled
+        and rolling_noise.windows
+        and rolling_limit_val is not None
+        and np.isfinite(rolling_noise.max_rsd)
+        and rolling_noise.max_rsd > rolling_limit_val
+    ):
+        flags.append("rolling_noise")
     if join.count and abs(join.max_offset) > join_limit:
         flags.append("join_offset")
     if spikes.count > spike_limit:
@@ -528,6 +620,7 @@ def compute_uvvis_qc(
         {
             "saturation": saturation,
             "noise": noise,
+            "rolling_noise": rolling_noise,
             "join": join,
             "spikes": spikes,
             "smoothing": smoothing,
@@ -539,6 +632,7 @@ def compute_uvvis_qc(
         "mode": _infer_mode(spec),
         "saturation": saturation,
         "noise": noise,
+        "rolling_noise": rolling_noise,
         "join": join,
         "spikes": spikes,
         "smoothing": smoothing,

--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -2191,6 +2191,7 @@ class UvVisPlugin(SpectroscopyPlugin):
             saturation = metrics["saturation"]
             join = metrics["join"]
             noise = metrics["noise"]
+            rolling_noise = metrics["rolling_noise"]
             spikes = metrics["spikes"]
             smoothing = metrics["smoothing"]
             drift = metrics["drift"]
@@ -2227,6 +2228,12 @@ class UvVisPlugin(SpectroscopyPlugin):
                 "noise_rsd": noise.rsd,
                 "noise_window": noise.window,
                 "noise_points": noise.used_points,
+                "rolling_noise_enabled": rolling_noise.enabled,
+                "rolling_noise_window_points": rolling_noise.window_points,
+                "rolling_noise_step_points": rolling_noise.step_points,
+                "rolling_noise_windows": rolling_noise.windows,
+                "rolling_noise_max_rsd": rolling_noise.max_rsd,
+                "rolling_noise_median_rsd": rolling_noise.median_rsd,
                 "join_count": join.count,
                 "join_max_offset": join.max_offset,
                 "join_mean_offset": join.mean_offset,

--- a/spectro_app/tests/test_uvvis_qc.py
+++ b/spectro_app/tests/test_uvvis_qc.py
@@ -45,6 +45,39 @@ def test_uvvis_analyze_produces_qc_metrics():
     assert row["noise_window"] == (400.0, 420.0)
 
 
+def test_uvvis_rolling_noise_disabled_without_recipe():
+    wl = np.linspace(200.0, 210.0, 21)
+    intensity = np.ones_like(wl)
+    spec = Spectrum(wavelength=wl, intensity=intensity, meta={"sample_id": "R0", "role": "sample"})
+
+    _, qc_rows = UvVisPlugin().analyze([spec], {})
+
+    row = qc_rows[0]
+    assert row["rolling_noise_enabled"] is False
+    assert row["rolling_noise_windows"] == 0
+    assert np.isnan(row["rolling_noise_max_rsd"])
+    assert "rolling_noise" not in row["flags"]
+
+
+def test_uvvis_rolling_noise_flags_exceeding_limit():
+    wl = np.linspace(200.0, 300.0, 201)
+    intensity = np.ones_like(wl)
+    intensity[80:120] = np.tile([0.2, 2.0], 20)
+    spec = Spectrum(wavelength=wl, intensity=intensity, meta={"sample_id": "R1", "role": "sample"})
+
+    recipe = {"qc": {"rolling_rsd": {"window": 20, "step": 5, "limit": 10.0}}}
+
+    _, qc_rows = UvVisPlugin().analyze([spec], recipe)
+
+    row = qc_rows[0]
+    assert row["rolling_noise_enabled"] is True
+    assert row["rolling_noise_windows"] > 0
+    assert row["rolling_noise_max_rsd"] > row["rolling_noise_median_rsd"]
+    assert row["rolling_noise_max_rsd"] > 10.0
+    assert "rolling_noise" in row["flags"]
+    assert any(part.startswith("Rolling noise") for part in row["summary"].split("; "))
+
+
 def _make_synthetic_spec(
     wl: np.ndarray,
     baseline: float,


### PR DESCRIPTION
## Summary
- add a rolling RSD helper in the QC engine and surface its metrics in UV-Vis QC summaries
- persist rolling noise statistics in UV-Vis QC rows and flag spectra that exceed configured thresholds
- extend UV-Vis QC tests with scenarios covering rolling-noise behaviour

## Testing
- pytest spectro_app/tests/test_uvvis_qc.py

------
https://chatgpt.com/codex/tasks/task_e_68e136fd49548324a0a4cc51a28c8585