### PR TITLE
Add anchored baseline zeroing for UV-Vis spectra

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -914,6 +914,14 @@ class UvVisPlugin(SpectroscopyPlugin):
                     "niter": baseline_cfg.get("niter", 10),
                     "iterations": baseline_cfg.get("iterations", 24),
                 }
+                anchor_cfg = (
+                    baseline_cfg.get("anchor")
+                    or baseline_cfg.get("anchor_windows")
+                    or baseline_cfg.get("anchors")
+                )
+                if anchor_cfg is None:
+                    anchor_cfg = baseline_cfg.get("zeroing")
+                params["anchor"] = anchor_cfg
                 working = pipeline.apply_baseline(working, method, **params)
 
             if smoothing_cfg.get("enabled"):
@@ -948,6 +956,12 @@ class UvVisPlugin(SpectroscopyPlugin):
                         p=baseline_cfg.get("p", 0.01),
                         niter=baseline_cfg.get("niter", 10),
                         iterations=baseline_cfg.get("iterations", 24),
+                        anchor=(
+                            baseline_cfg.get("anchor")
+                            or baseline_cfg.get("anchor_windows")
+                            or baseline_cfg.get("anchors")
+                            or baseline_cfg.get("zeroing")
+                        ),
                     )
                     for blank in blanks_working
                 ]


### PR DESCRIPTION
## Summary
- extend the UV-Vis baseline correction helper to support configurable anchor windows and record baseline anchor metadata
- thread the anchor configuration through the plugin preprocessing workflow so both blanks and samples are zeroed consistently
- add regression tests covering anchor zeroing at the pipeline layer and via the plugin preprocess path

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py

------
https://chatgpt.com/codex/tasks/task_e_68e13b3ef8f0832487059507f46b5286