### PR TITLE
Capture UV-Vis join corrections and expose QC metrics

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -2255,6 +2255,16 @@ class UvVisPlugin(SpectroscopyPlugin):
                 }
                 for name, values in derivatives.items()
             }
+            def _finite_max(values, *, absolute: bool = False) -> float:
+                arr = np.asarray(values, dtype=float)
+                if arr.size == 0:
+                    return float("nan")
+                if absolute:
+                    arr = np.abs(arr)
+                finite = arr[np.isfinite(arr)]
+                if finite.size == 0:
+                    return float("nan")
+                return float(np.nanmax(finite))
             row = {
                 "id": idx,
                 "sample_id": spec.meta.get("sample_id") or spec.meta.get("channel") or spec.meta.get("blank_id"),
@@ -2283,6 +2293,15 @@ class UvVisPlugin(SpectroscopyPlugin):
                 "join_mean_offset": join.mean_offset,
                 "join_max_overlap_error": join.max_overlap_error,
                 "join_indices": join.indices,
+                "join_offsets": join.offsets,
+                "join_pre_deltas": join.pre_deltas,
+                "join_post_deltas": join.post_deltas,
+                "join_pre_overlap_errors": join.pre_overlap_errors,
+                "join_post_overlap_errors": join.post_overlap_errors,
+                "join_pre_delta_abs_max": _finite_max(join.pre_deltas, absolute=True),
+                "join_post_delta_abs_max": _finite_max(join.post_deltas, absolute=True),
+                "join_pre_overlap_max": _finite_max(join.pre_overlap_errors),
+                "join_post_overlap_max": _finite_max(join.post_overlap_errors),
                 "spike_count": spikes.count,
                 "spike_threshold": spikes.threshold,
                 "smoothing_guard": smoothing.flag,

--- a/spectro_app/tests/test_pipeline_uvvis.py
+++ b/spectro_app/tests/test_pipeline_uvvis.py
@@ -785,6 +785,23 @@ def test_preprocess_uses_default_join_detection():
     assert processed_sample.meta.get("join_indices") == (join_idx,)
     assert processed_sample.meta.get("join_corrected") is True
 
+    stats = processed_sample.meta.get("join_statistics")
+    assert isinstance(stats, dict)
+    assert stats["indices"] == [join_idx]
+    assert stats["offsets"][0] == pytest.approx(stats["pre_deltas"][0], rel=1e-6)
+    assert stats["offsets"][0] > 0.3
+    assert stats["post_deltas"][0] == pytest.approx(0.0, abs=1e-6)
+
+    segments = processed_sample.meta.get("join_segments")
+    assert isinstance(segments, dict)
+    assert segments["indices"] == [join_idx]
+    assert len(segments["raw"]) == 2
+    assert len(segments["corrected"]) == 2
+
+    channels = processed_sample.meta.get("channels")
+    assert "join_raw" in channels
+    assert "join_corrected" in channels
+
     original_delta = np.max(np.abs(intensity - baseline))
     corrected_delta = np.max(np.abs(processed_sample.intensity - baseline))
     assert original_delta > 0.3

--- a/spectro_app/tests/test_uvvis_qc.py
+++ b/spectro_app/tests/test_uvvis_qc.py
@@ -54,6 +54,13 @@ def test_uvvis_analyze_produces_qc_metrics():
     assert row["saturation_flag"] is True
     assert row["spike_count"] >= 1
     assert row["join_count"] >= 1
+    assert isinstance(row["join_offsets"], list) and row["join_offsets"]
+    assert isinstance(row["join_pre_deltas"], list) and row["join_pre_deltas"]
+    assert isinstance(row["join_post_deltas"], list) and row["join_post_deltas"]
+    assert isinstance(row["join_pre_overlap_errors"], list)
+    assert isinstance(row["join_post_overlap_errors"], list)
+    assert row["join_pre_delta_abs_max"] >= row["join_post_delta_abs_max"]
+    assert row["join_post_overlap_max"] <= row["join_pre_overlap_max"] or np.isnan(row["join_pre_overlap_max"])
     assert np.isfinite(row["noise_rsd"]) and row["noise_rsd"] >= 0
     assert "saturation" in row["flags"]
     assert "Spikes" in row["summary"]


### PR DESCRIPTION
## Summary
- record join correction offsets, overlap deltas, and segment snapshots in UV-Vis preprocessing metadata so downstream consumers can compare raw vs. corrected segments
- enhance join QC diagnostics to use the stored metadata and expose before/after statistics from analysis outputs
- expand UV-Vis pipeline and QC tests to assert the new join metadata and metrics

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py::test_preprocess_uses_default_join_detection
- pytest spectro_app/tests/test_uvvis_qc.py::test_uvvis_analyze_produces_qc_metrics

------
https://chatgpt.com/codex/tasks/task_e_68e13e2ed9c4832490569b6626e339a0