### PR TITLE
Add QC noise histogram and trend figure generation

### DIFF
--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -109,6 +110,35 @@ def test_uvvis_export_creates_workbook_with_derivatives(tmp_path):
     assert result.figures, "Export should include generated plots"
     assert "qc_summary_noise.png" in result.figures
     assert any("Workbook written" in entry for entry in result.audit)
+
+
+def test_uvvis_export_generates_noise_histogram_and_trend(tmp_path):
+    plugin = UvVisPlugin()
+    base = _mock_spectrum()
+    base_time = datetime(2024, 1, 1, 9, 0)
+    rng = np.random.default_rng(42)
+    spectra = []
+    for idx in range(6):
+        meta = dict(base.meta)
+        meta["sample_id"] = f"Sample-{idx + 1}"
+        meta["acquired_datetime"] = (base_time + timedelta(minutes=idx * 5)).isoformat()
+        noise_scale = 0.002 + 0.001 * idx
+        noisy_intensity = base.intensity + rng.normal(scale=noise_scale, size=base.intensity.shape)
+        spectra.append(
+            Spectrum(
+                wavelength=base.wavelength.copy(),
+                intensity=noisy_intensity,
+                meta=meta,
+            )
+        )
+
+    recipe = {"export": {"path": str(tmp_path / "uvvis_hist_trend.xlsx")}}
+    processed, qc_rows = plugin.analyze(spectra, recipe)
+    result = plugin.export(processed, qc_rows, recipe)
+
+    assert "qc_summary_noise.png" in result.figures
+    assert "qc_summary_noise_hist.png" in result.figures
+    assert "qc_summary_noise_trend.png" in result.figures
 
 
 def test_uvvis_export_includes_pipeline_stage_channels(tmp_path):


### PR DESCRIPTION
## Summary
- enhance the UV-Vis QC summary figure renderer with reusable helpers to draw scatter, histogram, and timestamp trend plots when data support them
- ensure the new figures are exported (and therefore available to the PDF report) and extend export tests to assert their creation with timestamp-rich QC data

## Testing
- pytest spectro_app/tests/test_uvvis_export.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e142abdefc8324a3f5780588e2e92b