### PR TITLE
Add optional SVG figure exports for UV-Vis plugin

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Set
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Set, Mapping
 
 import numpy as np
 import pandas as pd
@@ -2481,7 +2481,12 @@ class UvVisPlugin(SpectroscopyPlugin):
         if not tokens:
             tokens.append("figure")
         base = "_".join(tokens)
-        return f"{base}.{ext}"
+        ext_str = str(ext or "").strip()
+        if ext_str.startswith("."):
+            ext_str = ext_str[1:]
+        if not ext_str:
+            return base
+        return f"{base}.{ext_str}"
 
     def _render_processed_figure(self, spec: Spectrum):
         wl = np.asarray(spec.wavelength, dtype=float)
@@ -2519,7 +2524,7 @@ class UvVisPlugin(SpectroscopyPlugin):
         self,
         spec: Spectrum,
         qc_row: Dict[str, object] | None = None,
-    ) -> List[Tuple[str, Figure]]:
+    ) -> List[Tuple[Tuple[str, ...], Figure]]:
         join_indices: Tuple[int, ...] = tuple()
         if qc_row and isinstance(qc_row.get("join_indices"), (list, tuple)):
             join_indices = tuple(
@@ -2557,7 +2562,7 @@ class UvVisPlugin(SpectroscopyPlugin):
         if not join_indices:
             return []
 
-        figures: List[Tuple[str, Figure]] = []
+        figures: List[Tuple[Tuple[str, ...], Figure]] = []
         sample_id = self._safe_sample_id(spec, f"spec_{id(spec)}")
         n = wl.size
         for order, join_idx in enumerate(join_indices, start=1):
@@ -2583,13 +2588,13 @@ class UvVisPlugin(SpectroscopyPlugin):
             ax.grid(True, alpha=0.2)
             ax.legend(loc="best")
             fig.tight_layout()
-            figures.append((self._sanitise_figure_name(sample_id, f"join_{order}"), fig))
+            figures.append(((sample_id, f"join_{order}"), fig))
         return figures
 
-    def _render_calibration_figures(self) -> List[Tuple[str, Figure]]:
+    def _render_calibration_figures(self) -> List[Tuple[Tuple[str, ...], Figure]]:
         calibration = getattr(self, "_last_calibration_results", None)
         targets = calibration.get("targets", []) if calibration else []
-        figures: List[Tuple[str, Figure]] = []
+        figures: List[Tuple[Tuple[str, ...], Figure]] = []
         for target in targets:
             standards = target.get("standards") or []
             if not standards:
@@ -2653,10 +2658,12 @@ class UvVisPlugin(SpectroscopyPlugin):
             ax_resid.grid(True, alpha=0.2)
 
             fig.tight_layout()
-            figures.append((self._sanitise_figure_name("calibration", str(target.get("name", "target"))), fig))
+            figures.append((("calibration", str(target.get("name", "target"))), fig))
         return figures
 
-    def _render_qc_summary_figures(self, qc_rows: Sequence[Dict[str, object]] | None) -> List[Tuple[str, Figure]]:
+    def _render_qc_summary_figures(
+        self, qc_rows: Sequence[Dict[str, object]] | None
+    ) -> List[Tuple[Tuple[str, ...], Figure]]:
         if not qc_rows:
             return []
         noise_values = np.array(
@@ -2690,13 +2697,15 @@ class UvVisPlugin(SpectroscopyPlugin):
         cbar = fig.colorbar(scatter, ax=ax)
         cbar.set_label("Join count")
         fig.tight_layout()
-        return [(self._sanitise_figure_name("qc", "summary", "noise"), fig)]
+        return [(("qc", "summary", "noise"), fig)]
 
     def _generate_figures(
         self,
         specs: List[Spectrum],
         qc_rows: Sequence[Dict[str, object]] | None = None,
+        formats: object = None,
     ) -> Tuple[Dict[str, bytes], List[Tuple[str, Figure]]]:
+        figure_formats = self._normalise_figure_formats(formats)
         figures: Dict[str, bytes] = {}
         figure_objs: List[Tuple[str, Figure]] = []
         qc_lookup: Dict[int, Dict[str, object]] = {}
@@ -2705,41 +2714,67 @@ class UvVisPlugin(SpectroscopyPlugin):
                 if isinstance(qc_row, dict):
                     qc_lookup[id(spec)] = qc_row
 
+        def capture(parts: Sequence[str], fig: Figure) -> None:
+            base_name = self._sanitise_figure_name(*parts, ext=figure_formats[0])
+            for fmt in figure_formats:
+                filename = self._sanitise_figure_name(*parts, ext=fmt)
+                buf = io.BytesIO()
+                save_kwargs = {"format": fmt}
+                if fmt == "png":
+                    save_kwargs["dpi"] = 150
+                fig.savefig(buf, **save_kwargs)
+                buf.seek(0)
+                figures[filename] = buf.read()
+            figure_objs.append((base_name, fig))
+
         for spec in specs:
             rendered = self._render_processed_figure(spec)
             if not rendered:
                 continue
             sample_id, fig = rendered
-            filename = self._sanitise_figure_name(sample_id, "processed")
-            buf = io.BytesIO()
-            fig.savefig(buf, format="png", dpi=150)
-            buf.seek(0)
-            figures[filename] = buf.read()
-            figure_objs.append((filename, fig))
+            capture((sample_id, "processed"), fig)
 
             qc_row = qc_lookup.get(id(spec))
-            for name, join_fig in self._render_join_overlap_figures(spec, qc_row):
-                buf = io.BytesIO()
-                join_fig.savefig(buf, format="png", dpi=150)
-                buf.seek(0)
-                figures[name] = buf.read()
-                figure_objs.append((name, join_fig))
+            for name_parts, join_fig in self._render_join_overlap_figures(spec, qc_row):
+                capture(name_parts, join_fig)
 
-        for name, cal_fig in self._render_calibration_figures():
-            buf = io.BytesIO()
-            cal_fig.savefig(buf, format="png", dpi=150)
-            buf.seek(0)
-            figures[name] = buf.read()
-            figure_objs.append((name, cal_fig))
+        for name_parts, cal_fig in self._render_calibration_figures():
+            capture(name_parts, cal_fig)
 
-        for name, qc_fig in self._render_qc_summary_figures(qc_rows):
-            buf = io.BytesIO()
-            qc_fig.savefig(buf, format="png", dpi=150)
-            buf.seek(0)
-            figures[name] = buf.read()
-            figure_objs.append((name, qc_fig))
+        for name_parts, qc_fig in self._render_qc_summary_figures(qc_rows):
+            capture(name_parts, qc_fig)
 
         return figures, figure_objs
+
+    @staticmethod
+    def _normalise_figure_formats(formats: object = None) -> Tuple[str, ...]:
+        default = ("png",)
+        if formats is None:
+            return default
+        candidates: List[str]
+        if isinstance(formats, Mapping):
+            candidates = [str(key) for key, value in formats.items() if value]
+        elif isinstance(formats, (str, bytes)):
+            candidates = [formats]
+        else:
+            try:
+                candidates = list(formats)  # type: ignore[arg-type]
+            except TypeError:
+                candidates = [str(formats)]
+        normalised: List[str] = []
+        for raw in candidates:
+            if raw is None:
+                continue
+            token = str(raw).strip().lower()
+            if not token:
+                continue
+            if token.startswith("."):
+                token = token[1:]
+            if token not in {"png", "svg"}:
+                continue
+            if token not in normalised:
+                normalised.append(token)
+        return tuple(normalised) if normalised else default
 
     @staticmethod
     def _coerce_export_path(value, default: Optional[Path] = None) -> Optional[Path]:
@@ -2812,7 +2847,7 @@ class UvVisPlugin(SpectroscopyPlugin):
     def export(self, specs, qc, recipe):
         export_cfg = dict(recipe.get("export", {})) if recipe else {}
         workbook_target = self._coerce_export_path(export_cfg.get("path") or export_cfg.get("workbook"))
-        figures, figure_objs = self._generate_figures(specs, qc)
+        figures, figure_objs = self._generate_figures(specs, qc, formats=export_cfg.get("formats"))
         audit_entries = self._build_audit_entries(specs, qc, recipe, figures)
         workbook_audit = list(audit_entries)
         calibration_results = getattr(self, "_last_calibration_results", None)

--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -177,6 +177,29 @@ def test_uvvis_export_includes_pipeline_stage_channels(tmp_path):
     assert data_row[smoothed_idx] is not None
     assert data_row[raw_idx] > data_row[smoothed_idx]
     assert data_row[raw_delta_idx] > 0.0
+
+
+def test_uvvis_export_emits_svg_when_requested(tmp_path):
+    plugin = UvVisPlugin()
+    spec = _mock_spectrum()
+    recipe = {
+        "export": {
+            "path": str(tmp_path / "uvvis_svg.xlsx"),
+            "formats": ["png", "svg"],
+        }
+    }
+
+    processed, qc_rows = plugin.analyze([spec], recipe)
+    result = plugin.export(processed, qc_rows, recipe)
+
+    expected_base = Path("Sample-1_processed")
+    png_name = expected_base.with_suffix(".png").name
+    svg_name = expected_base.with_suffix(".svg").name
+    assert png_name in result.figures
+    assert svg_name in result.figures
+    svg_stems = {Path(name).stem for name in result.figures if name.endswith(".svg")}
+    png_stems = {Path(name).stem for name in result.figures if name.endswith(".png")}
+    assert svg_stems <= png_stems
 def test_uvvis_export_audit_includes_runtime_and_input_hash(tmp_path):
     plugin = UvVisPlugin()
     spec = _mock_spectrum()


### PR DESCRIPTION
## Summary
- normalise UV-Vis export format configuration and generate each requested variant when rendering figures
- extend figure naming helpers and rendering routines to share figure objects while saving multiple formats
- add regression coverage ensuring SVG outputs accompany the existing PNG artefacts when enabled

## Testing
- pytest spectro_app/tests/test_uvvis_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e142a23e088324aadf141726e82aca