### PR TITLE
Add wide processed spectra layout option to UV-Vis export

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -2812,6 +2812,13 @@ class UvVisPlugin(SpectroscopyPlugin):
     def export(self, specs, qc, recipe):
         export_cfg = dict(recipe.get("export", {})) if recipe else {}
         workbook_target = self._coerce_export_path(export_cfg.get("path") or export_cfg.get("workbook"))
+        processed_layout = export_cfg.get("processed_layout", "tidy")
+        if isinstance(processed_layout, str):
+            processed_layout = processed_layout.lower()
+        else:
+            processed_layout = "tidy"
+        if processed_layout not in {"tidy", "wide"}:
+            processed_layout = "tidy"
         figures, figure_objs = self._generate_figures(specs, qc)
         audit_entries = self._build_audit_entries(specs, qc, recipe, figures)
         workbook_audit = list(audit_entries)
@@ -2840,6 +2847,7 @@ class UvVisPlugin(SpectroscopyPlugin):
                     workbook_audit,
                     figures,
                     calibration_results,
+                    processed_layout=processed_layout,
                 )
             else:
                 workbook_audit.append("No workbook path provided; workbook not written.")

--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -8,6 +8,7 @@ import numpy as np
 from importlib import metadata
 from openpyxl import load_workbook
 
+from spectro_app.engine import excel_writer
 from spectro_app.engine.plugin_api import Spectrum
 from spectro_app.plugins.uvvis.plugin import UvVisPlugin
 from spectro_app.plugins.uvvis import pipeline
@@ -109,6 +110,53 @@ def test_uvvis_export_creates_workbook_with_derivatives(tmp_path):
     assert result.figures, "Export should include generated plots"
     assert "qc_summary_noise.png" in result.figures
     assert any("Workbook written" in entry for entry in result.audit)
+
+
+def test_uvvis_export_supports_wide_processed_layout(tmp_path):
+    plugin = UvVisPlugin()
+    spec = _mock_spectrum()
+    recipe = {
+        "export": {
+            "path": str(tmp_path / "uvvis_wide.xlsx"),
+            "processed_layout": "wide",
+        }
+    }
+
+    processed, qc_rows = plugin.analyze([spec], recipe)
+    plugin.export(processed, qc_rows, recipe)
+
+    workbook_path = Path(recipe["export"]["path"])
+    assert workbook_path.exists(), "Wide workbook should be written"
+
+    wb = load_workbook(workbook_path)
+    ws_processed = wb["Processed_Spectra"]
+
+    header = [cell.value for cell in next(ws_processed.iter_rows(min_row=1, max_row=1))]
+    base_columns = ["spectrum_index", "sample_id", "role", "mode"]
+    assert header[: len(base_columns)] == base_columns
+
+    data_rows = list(ws_processed.iter_rows(min_row=2, values_only=True))
+    assert len(data_rows) == len(processed)
+
+    header_dynamic = set(header[len(base_columns) :])
+    expected_columns = set()
+    for spec in processed:
+        wavelengths = np.asarray(spec.wavelength, dtype=float)
+        for channel_label, _ in excel_writer._iter_channels(spec, wavelengths):
+            for wl_val in wavelengths:
+                expected_columns.add(excel_writer._format_channel_column(channel_label, float(wl_val)))
+
+    assert expected_columns == header_dynamic
+
+    column_index = {name: idx for idx, name in enumerate(header)}
+    for row, spec in zip(data_rows, processed):
+        wavelengths = np.asarray(spec.wavelength, dtype=float)
+        for channel_label, data in excel_writer._iter_channels(spec, wavelengths):
+            for wl_val, inten_val in zip(wavelengths, data):
+                col_name = excel_writer._format_channel_column(channel_label, float(wl_val))
+                cell_value = row[column_index[col_name]]
+                assert cell_value is not None
+                assert cell_value == pytest.approx(float(inten_val))
 
 
 def test_uvvis_export_includes_pipeline_stage_channels(tmp_path):


### PR DESCRIPTION
## Summary
- allow the Excel writer to emit processed spectra in tidy or wide layouts based on a recipe flag
- thread the processed layout option through the UV-Vis export path
- extend workbook tests to validate both tidy and wide processed sheets

## Testing
- pytest spectro_app/tests/test_uvvis_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e1429feb708324973888c269ea819f