### PR TITLE
Fix UV-Vis QC trend figure handling

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -2668,7 +2668,7 @@ class UvVisPlugin(SpectroscopyPlugin):
         if not qc_rows:
             return []
 
-        figures: List[Tuple[str, Figure]] = []
+        figures: List[Tuple[Tuple[str, ...], Figure]] = []
         noise_values = np.array(
             [row.get("noise_rsd", float("nan")) for row in qc_rows],
             dtype=float,
@@ -2684,15 +2684,15 @@ class UvVisPlugin(SpectroscopyPlugin):
         join_counts = np.array([row.get("join_count", 0) or 0 for row in qc_rows], dtype=float)
 
         scatter_fig = self._plot_noise_scatter(sample_labels, noise_values, join_counts, finite_mask)
-        figures.append((self._sanitise_figure_name("qc", "summary", "noise"), scatter_fig))
+        figures.append((("qc", "summary", "noise"), scatter_fig))
 
         hist_fig = self._plot_noise_histogram(noise_values[finite_mask])
         if hist_fig is not None:
-            figures.append((self._sanitise_figure_name("qc", "summary", "noise", "hist"), hist_fig))
+            figures.append((("qc", "summary", "noise", "hist"), hist_fig))
 
         timestamp_fig = self._plot_noise_trend(sample_labels, noise_values, qc_rows, finite_mask)
         if timestamp_fig is not None:
-            figures.append((self._sanitise_figure_name("qc", "summary", "noise", "trend"), timestamp_fig))
+            figures.append((("qc", "summary", "noise", "trend"), timestamp_fig))
 
         return figures
 
@@ -2821,7 +2821,7 @@ class UvVisPlugin(SpectroscopyPlugin):
         ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d\n%H:%M"))
         fig.autofmt_xdate()
         fig.tight_layout()
-        return [(("qc", "summary", "noise"), fig)]
+        return fig
 
     def _generate_figures(
         self,

--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -140,6 +140,35 @@ def test_uvvis_export_generates_noise_histogram_and_trend(tmp_path):
     assert "qc_summary_noise.png" in result.figures
     assert "qc_summary_noise_hist.png" in result.figures
     assert "qc_summary_noise_trend.png" in result.figures
+
+
+def test_uvvis_generate_figures_trend_uses_sanitised_name():
+    plugin = UvVisPlugin()
+    qc_rows = [
+        {
+            "sample_id": "QC-1",
+            "noise_rsd": 0.8,
+            "timestamp": "2024-01-01T09:00:00Z",
+        },
+        {
+            "sample_id": "QC-2",
+            "noise_rsd": 1.1,
+            "kinetics": {"timestamp": "2024-01-01T09:05:00+00:00"},
+        },
+    ]
+
+    figures, figure_objs = plugin._generate_figures([], qc_rows)
+
+    trend_keys = [name for name in figures if "noise_trend" in name]
+    assert trend_keys, "Noise trend figure should be generated when QC timestamps exist"
+
+    # The sanitised filename should remain stable so downstream exports keep the expected
+    # ``qc_summary_noise_trend.png`` path; this guards against regressions where the
+    # sanitisation logic was applied multiple times (producing ``..._png.png``).
+    assert "qc_summary_noise_trend.png" in figures
+
+    trend_obj_names = [name for name, _ in figure_objs if "noise_trend" in name]
+    assert trend_obj_names == ["qc_summary_noise_trend.png"]
 def test_uvvis_export_supports_wide_processed_layout(tmp_path):
     plugin = UvVisPlugin()
     spec = _mock_spectrum()


### PR DESCRIPTION
## Summary
- ensure the QC summary helpers return tuple-based name parts so figure filenames are sanitised exactly once
- make the noise trend helper return the Matplotlib Figure instead of a list wrapper
- add a regression test covering timestamped QC rows and the expected qc_summary_noise_trend.png output

## Testing
- pytest spectro_app/tests/test_uvvis_export.py::test_uvvis_generate_figures_trend_uses_sanitised_name -q
- pytest spectro_app/tests/test_uvvis_export.py::test_uvvis_export_generates_noise_histogram_and_trend -q

------
https://chatgpt.com/codex/tasks/task_e_68e1478b30808324aa9a242e22743fd5