### PR TITLE
Implement change-point join detection and bounded correction

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -827,7 +827,18 @@ class UvVisPlugin(SpectroscopyPlugin):
                     window=join_cfg.get("window", 10),
                 )
                 if joins:
-                    processed = pipeline.correct_joins(processed, joins, window=join_cfg.get("window", 10))
+                    bounds = join_cfg.get("offset_bounds")
+                    if bounds is None:
+                        bounds = (
+                            join_cfg.get("min_offset"),
+                            join_cfg.get("max_offset"),
+                        )
+                    processed = pipeline.correct_joins(
+                        processed,
+                        joins,
+                        window=join_cfg.get("window", 10),
+                        offset_bounds=bounds if bounds is not None else None,
+                    )
             if despike_cfg.get("enabled"):
                 processed = pipeline.despike_spectrum(
                     processed,


### PR DESCRIPTION
## Summary
- replace the UV-Vis join detector with a change-point style routine that searches rolling window medians for significant jumps
- clamp join correction offsets to recipe-provided bounds while keeping detailed join statistics
- add regression tests that cover smooth spectra, sharp joins, and bounded offset application

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py

------
https://chatgpt.com/codex/tasks/task_e_68e154e0cdcc8324aa22bae95ed488b1