### PR TITLE
Add instrument-specific UV-Vis join window defaults

### DIFF
--- a/spectro_app/plugins/uvvis/presets.yaml
+++ b/spectro_app/plugins/uvvis/presets.yaml
@@ -3,6 +3,10 @@ defaults:
     enabled: true
     window: 3
     threshold: 0.2
+    windows:
+      helios:
+        - min_nm: 340.0
+          max_nm: 360.0
   smoothing:
     enabled: false
     window: 15


### PR DESCRIPTION
## Summary
- add default Helios join wavelength windows to the UV-Vis plugin and ensure preprocess resolves instrument-specific recipes
- extend the join detection pipeline to accept optional wavelength windows and surface the configuration in presets
- cover the new behaviour with targeted tests and update existing expectations

## Testing
- `pytest spectro_app/tests/test_pipeline_uvvis.py`


------
https://chatgpt.com/codex/tasks/task_e_68e15d45b8788324a5a8bf330b8af949