### PR TITLE
Support weighted UV-Vis calibration regressions

### DIFF
--- a/spectro_app/engine/excel_writer.py
+++ b/spectro_app/engine/excel_writer.py
@@ -269,6 +269,8 @@ def _write_calibration_sheet(ws, calibration: Dict[str, Any] | None) -> None:
                 "Included",
                 "Replicates",
                 "Pathlength (cm)",
+                "Configured Weight",
+                "Applied Weight",
             ]
             ws.append(std_header)
             for entry in standards:
@@ -283,6 +285,8 @@ def _write_calibration_sheet(ws, calibration: Dict[str, Any] | None) -> None:
                         _clean_value(entry.get("included")),
                         _clean_value(entry.get("replicates")),
                         _clean_value(entry.get("pathlength_cm")),
+                        _clean_value(entry.get("weight")),
+                        _clean_value(entry.get("applied_weight")),
                     ]
                 )
         else:


### PR DESCRIPTION
## Summary
- apply weighted least-squares fits when calibration standards provide weights and propagate the values through residuals, limits, and QC/audit metadata
- add configured/applied weight tracking to exported calibration workbooks and attach weighting information to audit entries
- cover weighted calibration behaviour with regression and export tests

## Testing
- pytest spectro_app/tests/test_uvvis_export.py::test_uvvis_calibration_success spectro_app/tests/test_uvvis_export.py::test_uvvis_calibration_weighted_regression

------
https://chatgpt.com/codex/tasks/task_e_68e165c781f08324bbec0cdd73cdfb1a