### PR TITLE
Recognize legacy XLS exports in UV-Vis plugin detection

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -184,7 +184,10 @@ class UvVisPlugin(SpectroscopyPlugin):
         return domain
 
     def detect(self, paths):
-        return any(str(p).lower().endswith((".dsp", ".csv", ".xlsx", ".txt")) for p in paths)
+        return any(
+            str(p).lower().endswith((".dsp", ".csv", ".xlsx", ".xls", ".txt"))
+            for p in paths
+        )
 
     def load(self, paths: Iterable[str]) -> List[Spectrum]:
         spectra: List[Spectrum] = []

--- a/spectro_app/tests/test_uvvis_plugin_detect.py
+++ b/spectro_app/tests/test_uvvis_plugin_detect.py
@@ -1,0 +1,6 @@
+from spectro_app.plugins.uvvis.plugin import UvVisPlugin
+
+
+def test_uvvis_detect_accepts_xls_extension():
+    plugin = UvVisPlugin()
+    assert plugin.detect(["/path/to/spectrum.xls"]) is True


### PR DESCRIPTION
## Summary
- allow the UV-Vis plugin detector to recognise legacy `.xls` exports alongside existing formats
- add a unit test that ensures `.xls` paths return `True` from `UvVisPlugin.detect`

## Testing
- pytest spectro_app/tests/test_uvvis_plugin_detect.py

------
https://chatgpt.com/codex/tasks/task_e_68e169a519fc83248325fc52176633f0