### PR TITLE
Add default UV-Vis quiet window configuration

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -88,6 +88,7 @@ class UvVisPlugin(SpectroscopyPlugin):
             {"min_nm": 340.0, "max_nm": 360.0},
         ),
     }
+    DEFAULT_QC_QUIET_WINDOW_NM = (850.0, 900.0)
 
     def __init__(self, *, enable_manifest: bool = True) -> None:
         self.enable_manifest = bool(enable_manifest)
@@ -123,6 +124,25 @@ class UvVisPlugin(SpectroscopyPlugin):
         if join_defaults.get("windows") is None:
             join_defaults["windows"] = copy.deepcopy(self.DEFAULT_JOIN_WINDOWS_BY_INSTRUMENT)
         base["join"] = join_defaults
+
+        qc_cfg_raw = base.get("qc")
+        if qc_cfg_raw is None:
+            qc_cfg: Dict[str, object] = {}
+        elif isinstance(qc_cfg_raw, dict):
+            qc_cfg = dict(qc_cfg_raw)
+        else:
+            raise TypeError("QC configuration must be a mapping")
+
+        quiet_cfg = qc_cfg.get("quiet_window")
+        if quiet_cfg is None:
+            qc_cfg["quiet_window"] = {
+                "min": float(self.DEFAULT_QC_QUIET_WINDOW_NM[0]),
+                "max": float(self.DEFAULT_QC_QUIET_WINDOW_NM[1]),
+            }
+        elif not isinstance(quiet_cfg, Mapping):
+            raise TypeError("Quiet window configuration must be a mapping")
+
+        base["qc"] = qc_cfg
         return base
 
     def _resolve_join_windows(

--- a/spectro_app/plugins/uvvis/presets.yaml
+++ b/spectro_app/plugins/uvvis/presets.yaml
@@ -7,6 +7,10 @@ defaults:
       helios:
         - min_nm: 340.0
           max_nm: 360.0
+  qc:
+    quiet_window:
+      min: 850.0
+      max: 900.0
   smoothing:
     enabled: false
     window: 15

--- a/spectro_app/tests/test_uvvis_qc.py
+++ b/spectro_app/tests/test_uvvis_qc.py
@@ -72,6 +72,24 @@ def test_uvvis_analyze_produces_qc_metrics():
     assert row["roughness_delta"] == {}
 
 
+def test_uvvis_analyze_uses_default_quiet_window():
+    wl = np.linspace(800.0, 920.0, 121)
+    intensity = np.ones_like(wl)
+    spec = Spectrum(
+        wavelength=wl,
+        intensity=intensity,
+        meta={"sample_id": "Q1", "role": "sample"},
+    )
+
+    _, qc_rows = UvVisPlugin().analyze([spec], {})
+
+    assert len(qc_rows) == 1
+    row = qc_rows[0]
+
+    assert row["noise_window"] == (850.0, 900.0)
+    assert row["noise_points"] > 0
+
+
 def test_uvvis_qc_reports_roughness_for_stage_channels():
     wl = np.linspace(200.0, 260.0, 121)
     raw_intensity = np.sin(wl / 9.0) + 0.25 * np.sin(wl * 0.9)


### PR DESCRIPTION
## Summary
- default the UV-Vis QC quiet window to 850–900 nm when callers omit it
- add the same quiet window to the UV-Vis preset configuration for UI recipes
- cover the new default with a unit test for `UvVisPlugin.analyze`

## Testing
- pytest spectro_app/tests/test_uvvis_qc.py

------
https://chatgpt.com/codex/tasks/task_e_68e172bbd6d88324a126f0f08608651e