### PR TITLE
Populate UV-Vis preset defaults and add regression test

### DIFF
--- a/spectro_app/config/presets/uvvis_default.yaml
+++ b/spectro_app/config/presets/uvvis_default.yaml
@@ -1,3 +1,19 @@
 module: "uvvis"
-params: {}
+params:
+  join:
+    enabled: true
+    window: 3
+    threshold: 0.2
+    windows:
+      helios:
+        - min_nm: 340.0
+          max_nm: 360.0
+  qc:
+    quiet_window:
+      min: 850.0
+      max: 900.0
+  smoothing:
+    enabled: false
+    window: 15
+    polyorder: 3
 version: "0.1.0"

--- a/spectro_app/tests/test_presets.py
+++ b/spectro_app/tests/test_presets.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def test_uvvis_default_preset_includes_expected_params() -> None:
+    preset_path = Path(__file__).resolve().parent.parent / "config" / "presets" / "uvvis_default.yaml"
+    with preset_path.open("r", encoding="utf-8") as handle:
+        preset = yaml.safe_load(handle)
+
+    params = preset.get("params", {})
+
+    assert params.get("join") == {
+        "enabled": True,
+        "window": 3,
+        "threshold": 0.2,
+        "windows": {
+            "helios": [
+                {
+                    "min_nm": 340.0,
+                    "max_nm": 360.0,
+                }
+            ]
+        },
+    }
+
+    assert params.get("qc") == {
+        "quiet_window": {
+            "min": 850.0,
+            "max": 900.0,
+        }
+    }
+
+    assert params.get("smoothing") == {
+        "enabled": False,
+        "window": 15,
+        "polyorder": 3,
+    }


### PR DESCRIPTION
## Summary
- populate the UV-Vis default preset with the expected join, QC, and smoothing parameters
- add a regression test to ensure the preset retains the documented default settings

## Testing
- pytest spectro_app/tests/test_presets.py

------
https://chatgpt.com/codex/tasks/task_e_68e180131a7c832483d2bc0a881c6856