### PR TITLE
Normalize manifest alias metadata

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -477,10 +477,22 @@ class UvVisPlugin(SpectroscopyPlugin):
         skip_keys = {"file", "filename", "file_name", "data_file", "source_file", "path"}
         merged: Dict[str, object] = {}
         for entry in matches:
+            normalized_entry: Dict[str, object] = {}
             for key, value in entry.items():
-                if key in skip_keys:
-                    continue
+                norm_key = self._normalize_manifest_key(key)
+                normalized_entry[norm_key] = value
+
+            assignments = self._extract_manifest_assignments(normalized_entry)
+            for key, value in assignments.items():
                 merged[key] = value
+
+            for key, value in normalized_entry.items():
+                if key in skip_keys or key in assignments:
+                    continue
+                if key == "role" and isinstance(value, str):
+                    merged[key] = value.strip().lower()
+                else:
+                    merged[key] = value
         return merged
 
     # ------------------------------------------------------------------

--- a/spectro_app/tests/test_io_uvvis.py
+++ b/spectro_app/tests/test_io_uvvis.py
@@ -205,6 +205,74 @@ generic.csv,Blank Control,Blank-01,,ref-blank,QC,blank
     assert blank_spec.meta["role"] == "blank"
     assert blank_spec.meta["blank_id"] == "Blank Control"
     assert "replicate_id" not in blank_spec.meta
+
+
+def test_manifest_alias_assignments_from_excel(tmp_path):
+    generic_csv = """wavelength,Sample A,Sample B,Blank Control
+200,0.100,0.200,0.010
+205,0.105,0.205,0.011
+"""
+    data_path = tmp_path / "generic.csv"
+    data_path.write_text(generic_csv, encoding="utf-8")
+
+    manifest_rows = [
+        {
+            "File": "generic.csv",
+            "Channel": "Sample A",
+            "Sample": "Treated-A",
+            "Blank": "Blank-01",
+            "Replicate": "rep-1",
+            "Group": "Dose-Low",
+            "Role": "Sample",
+        },
+        {
+            "File": "generic.csv",
+            "Channel": "Sample B",
+            "Sample": "Treated-B",
+            "Blank": "Blank-01",
+            "Replicate": "rep-2",
+            "Group": "Dose-Low",
+            "Role": "SAMPLE",
+        },
+        {
+            "File": "generic.csv",
+            "Channel": "Blank Control",
+            "Sample": "Blank-01",
+            "Blank": "Blank-01",
+            "Replicate": "ref-blank",
+            "Group": "QC",
+            "Role": "BLANK",
+        },
+    ]
+    manifest_df = pd.DataFrame(manifest_rows)
+    manifest_path = tmp_path / "manifest.xlsx"
+    manifest_df.to_excel(manifest_path, index=False)
+
+    plugin = UvVisPlugin()
+    spectra = plugin.load([str(data_path), str(manifest_path)])
+
+    assert len(spectra) == 3
+
+    by_sample = {spec.meta["sample_id"]: spec for spec in spectra}
+    sample_a = by_sample["Treated-A"]
+    sample_b = by_sample["Treated-B"]
+    blank_spec = by_sample["Blank-01"]
+
+    assert sample_a.meta["blank_id"] == "Blank-01"
+    assert sample_a.meta["replicate_id"] == "rep-1"
+    assert sample_a.meta["group_id"] == "Dose-Low"
+    assert sample_a.meta["role"] == "sample"
+
+    assert sample_b.meta["replicate_id"] == "rep-2"
+    assert sample_b.meta["group_id"] == "Dose-Low"
+    assert sample_b.meta["role"] == "sample"
+
+    assert blank_spec.meta["role"] == "blank"
+    assert blank_spec.meta["blank_id"] == "Blank-01"
+    assert blank_spec.meta["replicate_id"] == "ref-blank"
+    assert blank_spec.meta["group_id"] == "QC"
+
+
 def test_manifest_named_csv_when_disabled(tmp_path):
     content = """wavelength,Sample
 200,0.100


### PR DESCRIPTION
## Summary
- ensure `_lookup_manifest_entries` uses manifest alias extraction so canonical metadata keys populate even when the index shortcut is unavailable
- add a UV-Vis manifest Excel test covering replicate, group, and role alias handling

## Testing
- pytest spectro_app/tests/test_io_uvvis.py

------
https://chatgpt.com/codex/tasks/task_e_68e18351a6ec8324b4d88ba7f6b2b109