### PR TITLE
Display run results in preview, QC, and logger docks

### DIFF
--- a/spectro_app/ui/docks/logger_view.py
+++ b/spectro_app/ui/docks/logger_view.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from PyQt6.QtGui import QTextCursor
 from PyQt6.QtWidgets import QDockWidget, QTextEdit
 
 class LoggerDock(QDockWidget):
@@ -5,3 +10,14 @@ class LoggerDock(QDockWidget):
         super().__init__("Logger", parent)
         self.text = QTextEdit(); self.text.setReadOnly(True)
         self.setWidget(self.text)
+
+    def clear(self):
+        self.text.clear()
+
+    def append_line(self, line: str):
+        self.text.append(line)
+        self.text.moveCursor(QTextCursor.MoveOperation.End)
+
+    def stream_lines(self, lines: Iterable[str]):
+        for line in lines:
+            self.append_line(line)

--- a/spectro_app/ui/docks/preview_widget.py
+++ b/spectro_app/ui/docks/preview_widget.py
@@ -1,6 +1,99 @@
-from PyQt6.QtWidgets import QDockWidget, QLabel
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+from PyQt6.QtWidgets import QDockWidget
+
+try:  # QtSvg is an optional dependency on some systems
+    from PyQt6.QtSvg import QSvgRenderer  # type: ignore
+except ImportError:  # pragma: no cover - fallback when QtSvg is unavailable
+    QSvgRenderer = None
 
 class PreviewDock(QDockWidget):
     def __init__(self, parent=None):
         super().__init__("Preview", parent)
-        self.setWidget(QLabel("Plot preview goes here"))
+        self.tabs = QtWidgets.QTabWidget()
+        self.tabs.setDocumentMode(True)
+        self.tabs.setTabsClosable(False)
+        self.tabs.setElideMode(QtCore.Qt.TextElideMode.ElideRight)
+        self.setWidget(self.tabs)
+        self.clear()
+
+    # ------------------------------------------------------------------
+    # Public API used by the main window
+    def clear(self):
+        """Reset the preview area to its empty state."""
+        self.tabs.clear()
+        self._add_message_tab("Preview", "Waiting for results…")
+
+    def show_error(self, message: str):
+        self.tabs.clear()
+        self._add_message_tab("Error", message)
+
+    def show_figures(self, figures: Dict[str, bytes]):
+        self.tabs.clear()
+        if not figures:
+            self._add_message_tab("Preview", "No figures were generated for this run.")
+            return
+
+        for idx, (name, data) in enumerate(figures.items(), start=1):
+            title = name or f"Figure {idx}"
+            pixmap = self._pixmap_from_bytes(data)
+            if pixmap is None:
+                self._add_message_tab(title, "Unable to render figure data.")
+                continue
+
+            container = QtWidgets.QWidget()
+            layout = QtWidgets.QVBoxLayout(container)
+            layout.setContentsMargins(12, 12, 12, 12)
+            layout.setSpacing(12)
+
+            label = QtWidgets.QLabel()
+            label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+            label.setPixmap(pixmap)
+            label.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding)
+
+            layout.addWidget(label)
+
+            scroll = QtWidgets.QScrollArea()
+            scroll.setWidgetResizable(True)
+            scroll.setWidget(container)
+
+            self.tabs.addTab(scroll, title)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _add_message_tab(self, title: str, message: str):
+        label = QtWidgets.QLabel(message)
+        label.setWordWrap(True)
+        label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.tabs.addTab(label, title)
+
+    def _pixmap_from_bytes(self, data: bytes) -> Optional[QtGui.QPixmap]:
+        if not data:
+            return None
+
+        pixmap = QtGui.QPixmap()
+        if pixmap.loadFromData(data):  # Handles PNG and other raster formats
+            return pixmap
+
+        if QSvgRenderer is None:
+            return None
+
+        renderer = QSvgRenderer(QtCore.QByteArray(data))
+        if not renderer.isValid():
+            return None
+
+        size = renderer.defaultSize()
+        if not size.isValid():
+            size = QtCore.QSize(800, 600)
+
+        image = QtGui.QImage(size, QtGui.QImage.Format.Format_ARGB32)
+        image.fill(QtCore.Qt.GlobalColor.transparent)
+
+        painter = QtGui.QPainter(image)
+        renderer.render(painter)
+        painter.end()
+
+        return QtGui.QPixmap.fromImage(image)

--- a/spectro_app/ui/docks/qc_widget.py
+++ b/spectro_app/ui/docks/qc_widget.py
@@ -1,6 +1,50 @@
-from PyQt6.QtWidgets import QDockWidget, QLabel
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from PyQt6 import QtGui, QtWidgets
+from PyQt6.QtWidgets import QDockWidget
 
 class QCDock(QDockWidget):
     def __init__(self, parent=None):
         super().__init__("QC Panel", parent)
-        self.setWidget(QLabel("QC table and charts go here"))
+        self.table = QtWidgets.QTableView(self)
+        self.table.setAlternatingRowColors(True)
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.SingleSelection)
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.model = QtGui.QStandardItemModel(self.table)
+        self.table.setModel(self.model)
+        self.setWidget(self.table)
+        self.clear()
+
+    def clear(self):
+        self.model.clear()
+        self.model.setHorizontalHeaderLabels(["QC"])
+        self.model.appendRow([QtGui.QStandardItem("Awaiting quality control results…")])
+        self.table.resizeColumnsToContents()
+
+    def show_qc_table(self, rows: Iterable[Dict[str, object]]):
+        data = list(rows)
+        self.model.clear()
+
+        if not data:
+            self.model.setHorizontalHeaderLabels(["QC"])
+            self.model.appendRow([QtGui.QStandardItem("No QC metrics were reported.")])
+            self.table.resizeColumnsToContents()
+            return
+
+        headers = sorted({key for row in data for key in row.keys()})
+        self.model.setColumnCount(len(headers))
+        self.model.setHorizontalHeaderLabels(headers)
+
+        for row in data:
+            items: List[QtGui.QStandardItem] = []
+            for header in headers:
+                value = row.get(header, "")
+                item = QtGui.QStandardItem(str(value))
+                item.setEditable(False)
+                items.append(item)
+            self.model.appendRow(items)
+
+        self.table.resizeColumnsToContents()


### PR DESCRIPTION
## Summary
- replace the placeholder docks with widgets that can render figures, QC tables, and logs
- add helpers to deserialize figure bytes, populate QC table models, and stream audit text
- hook the docks up to RunController signals so runs clear views and display results or errors

## Testing
- python -m compileall spectro_app/ui/docks/preview_widget.py spectro_app/ui/docks/qc_widget.py spectro_app/ui/docks/logger_view.py spectro_app/ui/main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68e1875c7a148324804ef1d4fa1cb214