### PR TITLE
Add drag-and-drop handling to file queue dock

### DIFF
--- a/spectro_app/ui/docks/file_queue.py
+++ b/spectro_app/ui/docks/file_queue.py
@@ -1,7 +1,181 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional
+
+from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtWidgets import QDockWidget, QListWidget
 
+
 class FileQueueDock(QDockWidget):
-    def __init__(self, parent=None):
+    paths_dropped = QtCore.pyqtSignal(list)
+    inspect_requested = QtCore.pyqtSignal(str)
+    preview_requested = QtCore.pyqtSignal(str)
+    locate_requested = QtCore.pyqtSignal(str)
+
+    def __init__(
+        self,
+        parent: Optional[QtWidgets.QWidget] = None,
+        *,
+        plugin_resolver: Optional[Callable[[List[str]], object]] = None,
+    ) -> None:
         super().__init__("File Queue", parent)
         self.list = QListWidget()
         self.setWidget(self.list)
+        self.setAcceptDrops(True)
+        self._plugin_resolver = plugin_resolver
+
+    def set_plugin_resolver(
+        self, resolver: Optional[Callable[[List[str]], object]]
+    ) -> None:
+        self._plugin_resolver = resolver
+
+    # ------------------------------------------------------------------
+    # Drag and drop handling
+    def dragEnterEvent(self, event: QtGui.QDragEnterEvent) -> None:  # type: ignore[name-defined]
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dragMoveEvent(self, event: QtGui.QDragMoveEvent) -> None:  # type: ignore[name-defined]
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event: QtGui.QDropEvent) -> None:  # type: ignore[name-defined]
+        if not event.mimeData().hasUrls():
+            event.ignore()
+            return
+
+        event.setDropAction(QtCore.Qt.DropAction.CopyAction)
+        event.accept()
+
+        urls = event.mimeData().urls()
+        ordered_paths: List[Path] = []
+        seen: set[Path] = set()
+
+        for url in urls:
+            if not url.isLocalFile():
+                continue
+            resolved = Path(url.toLocalFile()).expanduser().resolve()
+            if resolved in seen:
+                continue
+            if resolved.is_dir():
+                for path in sorted(self._iter_directory(resolved)):
+                    if path not in seen:
+                        ordered_paths.append(path)
+                        seen.add(path)
+                continue
+            if resolved.is_file():
+                ordered_paths.append(resolved)
+                seen.add(resolved)
+
+        if not ordered_paths:
+            return
+
+        manifest_paths: List[Path] = []
+        data_paths: List[Path] = []
+        plugin = self._resolve_plugin_for_paths(ordered_paths)
+
+        if plugin and hasattr(plugin, "_is_manifest_file"):
+            for path in ordered_paths:
+                try:
+                    is_manifest = bool(plugin._is_manifest_file(path))  # type: ignore[attr-defined]
+                except Exception:
+                    is_manifest = False
+                if is_manifest:
+                    manifest_paths.append(path)
+                else:
+                    data_paths.append(path)
+        else:
+            data_paths = list(ordered_paths)
+
+        include_manifests = True
+        if manifest_paths and data_paths:
+            include_manifests = self._confirm_manifest_inclusion(manifest_paths)
+            if include_manifests is None:
+                return
+
+        final_paths: List[str]
+        if include_manifests:
+            final_paths = [str(p) for p in ordered_paths]
+        else:
+            final_paths = [str(p) for p in ordered_paths if p in data_paths]
+
+        if final_paths:
+            self.paths_dropped.emit(final_paths)
+
+    def _iter_directory(self, directory: Path) -> Iterable[Path]:
+        for candidate in directory.rglob("*"):
+            if candidate.is_file():
+                yield candidate
+
+    def _confirm_manifest_inclusion(self, manifest_paths: List[Path]) -> Optional[bool]:
+        names = "\n".join(path.name for path in manifest_paths[:5])
+        if len(manifest_paths) > 5:
+            names += "\n…"
+        message = (
+            "Manifest files were detected along with spectra.\n\n"
+            "Include the manifests when updating the queue?"
+        )
+        if names:
+            message += f"\n\nDetected manifests:\n{names}"
+
+        choice = QtWidgets.QMessageBox.question(
+            self,
+            "Include Manifest Files?",
+            message,
+            QtWidgets.QMessageBox.StandardButton.Yes
+            | QtWidgets.QMessageBox.StandardButton.No
+            | QtWidgets.QMessageBox.StandardButton.Cancel,
+            QtWidgets.QMessageBox.StandardButton.Yes,
+        )
+
+        if choice == QtWidgets.QMessageBox.StandardButton.Cancel:
+            return None
+        if choice == QtWidgets.QMessageBox.StandardButton.No:
+            return False
+        return True
+
+    def _resolve_plugin_for_paths(self, paths: Iterable[Path]):
+        if not self._plugin_resolver:
+            return None
+        try:
+            return self._plugin_resolver([str(p) for p in paths])
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------
+    # Context menu actions
+    def contextMenuEvent(self, event: QtGui.QContextMenuEvent) -> None:  # type: ignore[name-defined]
+        menu = QtWidgets.QMenu(self)
+        selected_path = self._selected_path()
+
+        inspect_action = menu.addAction("Inspect Header…")
+        preview_action = menu.addAction("Preview…")
+        menu.addSeparator()
+        locate_action = menu.addAction("Show in File Manager")
+
+        enabled = bool(selected_path)
+        inspect_action.setEnabled(enabled)
+        preview_action.setEnabled(enabled)
+        locate_action.setEnabled(enabled)
+
+        action = menu.exec(event.globalPos()) if menu.actions() else None
+        if not action or not selected_path:
+            return
+        path = selected_path
+        if action is inspect_action:
+            self.inspect_requested.emit(path)
+        elif action is preview_action:
+            self.preview_requested.emit(path)
+        elif action is locate_action:
+            self.locate_requested.emit(path)
+
+    def _selected_path(self) -> Optional[str]:
+        items = self.list.selectedItems()
+        if not items:
+            return None
+        return items[0].text()

--- a/spectro_app/ui/main_window.py
+++ b/spectro_app/ui/main_window.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from PyQt6 import QtCore, QtWidgets
+from PyQt6.QtGui import QDesktopServices
 
 from spectro_app.engine.plugin_api import BatchResult
 from spectro_app.engine.recipe_model import Recipe
@@ -58,6 +59,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._queued_paths: List[str] = []
         self._recipe_data: Dict[str, Any] = self._normalise_recipe_data({})
+        self.fileDock.set_plugin_resolver(
+            lambda paths: self._resolve_plugin(paths, self._recipe_data.get("module"))
+        )
         self._current_recipe_path: Optional[Path] = None
         self._last_result: Optional[BatchResult] = None
         self._active_plugin = None
@@ -74,6 +78,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _init_docks(self):
         self.fileDock = FileQueueDock(self)
+        self.fileDock.paths_dropped.connect(self._on_queue_paths_dropped)
+        self.fileDock.inspect_requested.connect(self._on_queue_inspect_requested)
+        self.fileDock.preview_requested.connect(self._on_queue_preview_requested)
+        self.fileDock.locate_requested.connect(self._on_queue_locate_requested)
         self.addDockWidget(QtCore.Qt.DockWidgetArea.LeftDockWidgetArea, self.fileDock)
         self.recipeDock = RecipeEditorDock(self)
         self.addDockWidget(QtCore.Qt.DockWidgetArea.RightDockWidgetArea, self.recipeDock)
@@ -345,6 +353,96 @@ class MainWindow(QtWidgets.QMainWindow):
             else "Queue cleared"
         )
         self.status.showMessage(message, 5000)
+
+    # ------------------------------------------------------------------
+    # File queue interactions
+    def _on_queue_paths_dropped(self, paths: List[str]):
+        if not paths:
+            return
+        self._set_queue(paths)
+        first_existing = next((Path(p) for p in paths if Path(p).exists()), None)
+        if first_existing:
+            target_dir = first_existing.parent if first_existing.is_file() else first_existing
+            if target_dir.is_dir():
+                self._export_default_dir = target_dir
+
+    def _on_queue_inspect_requested(self, path: str):
+        self._open_file_preview(Path(path), "Inspect Header", 4096)
+
+    def _on_queue_preview_requested(self, path: str):
+        self._open_file_preview(Path(path), "Preview", 65536)
+
+    def _on_queue_locate_requested(self, path: str):
+        target = Path(path)
+        if not target.exists():
+            QtWidgets.QMessageBox.warning(
+                self,
+                "File Not Found",
+                f"The file '{path}' could not be found on disk.",
+            )
+            return
+        directory = target.parent if target.is_file() else target
+        QDesktopServices.openUrl(QtCore.QUrl.fromLocalFile(str(directory.resolve())))
+
+    def _open_file_preview(self, path: Path, title: str, max_bytes: int):
+        if not path.exists():
+            QtWidgets.QMessageBox.warning(
+                self,
+                "File Not Found",
+                f"The file '{path}' could not be found on disk.",
+            )
+            return
+
+        try:
+            with path.open("rb") as handle:
+                data = handle.read(max_bytes + 1)
+        except Exception as exc:  # pragma: no cover - filesystem error path
+            QtWidgets.QMessageBox.critical(
+                self,
+                f"Unable to Open {title}",
+                f"Failed to open '{path}': {exc}",
+            )
+            return
+
+        text = data.decode("utf-8", errors="replace")
+        truncated = len(data) > max_bytes
+        if truncated:
+            text += "\n\n… output truncated …"
+
+        dialog = QtWidgets.QDialog(self)
+        dialog.setWindowTitle(f"{title} — {path.name}")
+        dialog.setModal(True)
+
+        layout = QtWidgets.QVBoxLayout(dialog)
+        info = QtWidgets.QLabel(str(path))
+        info.setTextInteractionFlags(
+            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            | QtCore.Qt.TextInteractionFlag.LinksAccessibleByMouse
+        )
+        layout.addWidget(info)
+
+        text_edit = QtWidgets.QPlainTextEdit()
+        text_edit.setReadOnly(True)
+        text_edit.setLineWrapMode(QtWidgets.QPlainTextEdit.LineWrapMode.NoWrap)
+        text_edit.setPlainText(text)
+        layout.addWidget(text_edit)
+
+        if truncated:
+            notice = QtWidgets.QLabel(
+                "Only a portion of the file is shown to keep the preview responsive."
+            )
+            notice.setWordWrap(True)
+            layout.addWidget(notice)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Close
+        )
+        buttons.rejected.connect(dialog.reject)
+        buttons.accepted.connect(dialog.accept)
+        layout.addWidget(buttons)
+
+        dialog.resize(900, 600 if max_bytes > 8192 else 520)
+        dialog.exec()
 
     def _normalise_recipe_data(self, data: Dict[str, Any]) -> Dict[str, Any]:
         base = dict(data or {})


### PR DESCRIPTION
## Summary
- enable drag-and-drop on the file queue, including manifest prompts and context menu actions
- propagate new file queue signals to update the queue, preview files, and locate them on disk
- add lightweight file preview dialogs powered by the main window helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e190a5a9388324ac36109225aacbb1