### PR TITLE
Handle prompts when closing with running jobs or unsaved changes

### DIFF
--- a/spectro_app/app_context.py
+++ b/spectro_app/app_context.py
@@ -1,5 +1,6 @@
 from PyQt6.QtCore import QSettings
 
+
 class AppContext:
     def __init__(self):
         # Company/app keys control where QSettings persists per OS
@@ -10,9 +11,14 @@ class AppContext:
     def set_dirty(self, dirty: bool):
         self._dirty = dirty
 
+    def is_dirty(self) -> bool:
+        return self._dirty
+
     def set_job_running(self, running: bool):
         self._job_running = running
 
+    def is_job_running(self) -> bool:
+        return self._job_running
+
     def maybe_close(self) -> bool:
-        # TODO: hook into recipe dirty state and running jobs
-        return not self._job_running
+        return not (self._job_running or self._dirty)

--- a/spectro_app/tests/conftest.py
+++ b/spectro_app/tests/conftest.py
@@ -1,6 +1,9 @@
+import os
 import sys
 from pathlib import Path
 
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:

--- a/spectro_app/tests/test_mainwindow_close.py
+++ b/spectro_app/tests/test_mainwindow_close.py
@@ -1,0 +1,127 @@
+import pytest
+
+try:  # pragma: no cover - environment-specific skip
+    from PyQt6 import QtGui, QtWidgets
+except ImportError:  # pragma: no cover - environment-specific skip
+    pytest.skip("PyQt6 is unavailable", allow_module_level=True)
+
+from spectro_app.app_context import AppContext
+from spectro_app.ui.main_window import MainWindow
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+@pytest.fixture
+def main_window(qapp):
+    ctx = AppContext()
+    window = MainWindow(ctx)
+    yield window
+    window.appctx.set_dirty(False)
+    window.appctx.set_job_running(False)
+    window.deleteLater()
+
+
+def _close_event():
+    return QtGui.QCloseEvent()
+
+
+def test_close_event_cancel_job_requests_cancel(main_window):
+    main_window.appctx.set_job_running(True)
+
+    called = {}
+
+    def fake_prompt():
+        return "cancel"
+
+    def fake_cancel():
+        called["cancelled"] = True
+
+    main_window._prompt_job_running_action = fake_prompt
+    main_window.on_cancel = fake_cancel
+    event = _close_event()
+
+    main_window.closeEvent(event)
+
+    assert called == {"cancelled": True}
+    assert not event.isAccepted()
+    assert main_window.appctx.is_job_running()
+
+
+def test_close_event_force_stop_allows_close(main_window):
+    main_window.appctx.set_job_running(True)
+
+    cancelled = {}
+
+    def fake_prompt():
+        return "force"
+
+    def fake_cancel_job():
+        cancelled["runctl"] = True
+        return True
+
+    main_window._prompt_job_running_action = fake_prompt
+    main_window.runctl.cancel = fake_cancel_job
+    event = _close_event()
+
+    main_window.closeEvent(event)
+
+    assert cancelled == {"runctl": True}
+    assert main_window.appctx.is_job_running() is False
+    assert event.isAccepted()
+
+
+def test_close_event_dirty_save(main_window):
+    main_window.appctx.set_dirty(True)
+
+    def fake_prompt():
+        return "save"
+
+    def fake_save():
+        main_window.appctx.set_dirty(False)
+
+    main_window._prompt_unsaved_changes = fake_prompt
+    main_window.on_save_recipe = fake_save
+    event = _close_event()
+
+    main_window.closeEvent(event)
+
+    assert event.isAccepted()
+    assert main_window.appctx.is_dirty() is False
+
+
+def test_close_event_dirty_cancel(main_window):
+    main_window.appctx.set_dirty(True)
+
+    def fake_prompt():
+        return "cancel"
+
+    main_window._prompt_unsaved_changes = fake_prompt
+    event = _close_event()
+
+    main_window.closeEvent(event)
+
+    assert not event.isAccepted()
+    assert main_window.appctx.is_dirty()
+
+
+def test_dirty_state_triggers_prompt(main_window):
+    main_window.appctx.set_dirty(True)
+    called = {}
+
+    def fake_prompt():
+        called["prompted"] = True
+        return "cancel"
+
+    main_window._prompt_unsaved_changes = fake_prompt
+    event = _close_event()
+
+    main_window.closeEvent(event)
+
+    assert called == {"prompted": True}
+    assert not event.isAccepted()

--- a/spectro_app/ui/main_window.py
+++ b/spectro_app/ui/main_window.py
@@ -123,7 +123,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.progress.setValue(0)
 
     def _collect_actions(self):
-        actions = {action.text(): action for action in self.findChildren(QtWidgets.QAction)}
+        actions = {action.text(): action for action in self.findChildren(QtGui.QAction)}
         self._open_action = actions.get("Open...")
         self._save_recipe_action = actions.get("Save Recipe")
         self._save_recipe_as_action = actions.get("Save Recipe As...")
@@ -469,11 +469,79 @@ class MainWindow(QtWidgets.QMainWindow):
         self.status.showMessage(f"Opened log folder: {log_dir}", 5000)
 
     def closeEvent(self, e):
-        if not self.appctx.maybe_close():
-            e.ignore()
-            return
+        if self.appctx.is_job_running():
+            job_action = self._prompt_job_running_action()
+            if job_action == "cancel":
+                self.on_cancel()
+                e.ignore()
+                return
+            if job_action != "force":
+                e.ignore()
+                return
+            if self.runctl.cancel():
+                self.status.showMessage("Force stopping job...", 5000)
+            self._job_running = False
+            self.appctx.set_job_running(False)
+
+        if self.appctx.is_dirty():
+            dirty_action = self._prompt_unsaved_changes()
+            if dirty_action == "cancel":
+                e.ignore()
+                return
+            if dirty_action == "save":
+                self.on_save_recipe()
+                if self.appctx.is_dirty():
+                    e.ignore()
+                    return
+            elif dirty_action == "discard":
+                self.appctx.set_dirty(False)
+
         self.save_state()
         super().closeEvent(e)
+
+    def _prompt_job_running_action(self) -> str:
+        box = QtWidgets.QMessageBox(self)
+        box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        box.setWindowTitle("Job Running")
+        box.setText(
+            "A processing job is currently running. Choose an option to continue."
+        )
+        cancel_job = box.addButton(
+            "Cancel Job", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+        )
+        force_stop = box.addButton(
+            "Force Stop", QtWidgets.QMessageBox.ButtonRole.DestructiveRole
+        )
+        stay_open = box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+        box.setDefaultButton(stay_open)
+        box.exec()
+        clicked = box.clickedButton()
+        if clicked == cancel_job:
+            return "cancel"
+        if clicked == force_stop:
+            return "force"
+        return "abort"
+
+    def _prompt_unsaved_changes(self) -> str:
+        box = QtWidgets.QMessageBox(self)
+        box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        box.setWindowTitle("Unsaved Changes")
+        box.setText(
+            "You have unsaved recipe changes. Do you want to save before exiting?"
+        )
+        save_btn = box.addButton("Save", QtWidgets.QMessageBox.ButtonRole.AcceptRole)
+        discard_btn = box.addButton(
+            "Discard", QtWidgets.QMessageBox.ButtonRole.DestructiveRole
+        )
+        cancel_btn = box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+        box.setDefaultButton(save_btn)
+        box.exec()
+        clicked = box.clickedButton()
+        if clicked == save_btn:
+            return "save"
+        if clicked == discard_btn:
+            return "discard"
+        return "cancel"
 
     def save_state(self):
         s = self.appctx.settings

--- a/spectro_app/ui/menus.py
+++ b/spectro_app/ui/menus.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QAction
+from PyQt6.QtGui import QAction
 
 def build_menus(window):
     menubar = window.menuBar()


### PR DESCRIPTION
## Summary
- add helper accessors to AppContext for tracking dirty state and running jobs
- update the main window close flow to prompt about running jobs or unsaved recipes and adjust QAction usage for PyQt6
- add tests for the close-event decision logic and configure the test suite for headless Qt

## Testing
- pytest spectro_app/tests/test_mainwindow_close.py

------
https://chatgpt.com/codex/tasks/task_e_68e193bac98c832480dba39725570148