### PR TITLE
Add Open Recent menu and sync with recent file settings

### DIFF
--- a/spectro_app/tests/test_recent_menu.py
+++ b/spectro_app/tests/test_recent_menu.py
@@ -1,0 +1,98 @@
+import os
+from pathlib import Path
+
+import pytest
+from PyQt6 import QtCore, QtWidgets
+
+from spectro_app.ui.main_window import MainWindow
+
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+class DummyAppContext:
+    def __init__(self, settings: QtCore.QSettings):
+        self.settings = settings
+
+    def set_dirty(self, dirty: bool):
+        pass
+
+    def set_job_running(self, running: bool):
+        pass
+
+    def maybe_close(self) -> bool:
+        return True
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def _make_settings(tmp_path: Path) -> QtCore.QSettings:
+    settings_path = tmp_path / "test_settings.ini"
+    if settings_path.exists():
+        settings_path.unlink()
+    settings = QtCore.QSettings(str(settings_path), QtCore.QSettings.Format.IniFormat)
+    settings.clear()
+    return settings
+
+
+def test_recent_menu_shows_placeholder_when_empty(qapp, tmp_path):
+    settings = _make_settings(tmp_path)
+    settings.setValue("recentFiles", [])
+    window = MainWindow(DummyAppContext(settings))
+    try:
+        actions = window._recent_menu.actions()
+        assert len(actions) == 1
+        placeholder = actions[0]
+        assert not placeholder.isEnabled()
+        assert "No Recent Files" in placeholder.text()
+    finally:
+        window.close()
+        window.deleteLater()
+
+
+def test_recent_menu_prunes_missing_entries(qapp, tmp_path):
+    settings = _make_settings(tmp_path)
+    existing = tmp_path / "data.txt"
+    existing.write_text("sample")
+    missing = tmp_path / "missing.txt"
+    settings.setValue("recentFiles", [str(existing), str(missing)])
+
+    window = MainWindow(DummyAppContext(settings))
+    try:
+        actions = [action for action in window._recent_menu.actions() if action.isEnabled()]
+        assert len(actions) == 1
+        assert actions[0].text() == str(existing)
+
+        stored = window._coerce_settings_list(settings.value("recentFiles", []))
+        assert stored == [str(existing)]
+    finally:
+        window.close()
+        window.deleteLater()
+
+
+def test_recent_menu_limits_to_twenty_items(qapp, tmp_path):
+    settings = _make_settings(tmp_path)
+    paths = []
+    for idx in range(25):
+        path = tmp_path / f"file_{idx}.dat"
+        path.write_text("data")
+        paths.append(str(path))
+    settings.setValue("recentFiles", paths)
+
+    window = MainWindow(DummyAppContext(settings))
+    try:
+        actions = [action.text() for action in window._recent_menu.actions() if action.isEnabled()]
+        assert actions == paths[:20]
+
+        stored = window._coerce_settings_list(settings.value("recentFiles", []))
+        assert len(stored) == 20
+        assert stored == paths[:20]
+    finally:
+        window.close()
+        window.deleteLater()

--- a/spectro_app/ui/dialogs/settings_dialog.py
+++ b/spectro_app/ui/dialogs/settings_dialog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List
+from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QComboBox,
@@ -22,6 +23,8 @@ from PyQt6.QtWidgets import (
 
 class SettingsDialog(QDialog):
     """Application preferences editor."""
+
+    recent_files_changed = pyqtSignal(list)
 
     def __init__(self, settings, parent: QWidget | None = None):
         super().__init__(parent)
@@ -145,14 +148,17 @@ class SettingsDialog(QDialog):
             if path and path not in current:
                 self._recent_list.addItem(path)
                 current.append(path)
+        self._emit_recent_changed()
 
     def _on_remove_recent(self):
         for item in self._recent_list.selectedItems():
             row = self._recent_list.row(item)
             self._recent_list.takeItem(row)
+        self._emit_recent_changed()
 
     def _on_clear_recent(self):
         self._recent_list.clear()
+        self._emit_recent_changed()
 
     def _on_browse_export_dir(self):
         start_dir = self._export_dir_edit.text().strip() or str(Path.home())
@@ -164,3 +170,6 @@ class SettingsDialog(QDialog):
         container = QWidget()
         container.setLayout(layout)
         return container
+
+    def _emit_recent_changed(self):
+        self.recent_files_changed.emit(self._collect_recent_files())

--- a/spectro_app/ui/main_window.py
+++ b/spectro_app/ui/main_window.py
@@ -1,5 +1,6 @@
 import copy
 import json
+from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -36,7 +37,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.appctx = appctx
         self.setWindowTitle("Spectroscopy Processing App")
         self.resize(1280, 800)
+        self._recent_menu = None
+        self._recent_placeholder_text = "No Recent Files"
         build_menus(self)
+        self._refresh_recent_menu()
         self._collect_actions()
         self._init_toolbar()
         self._init_docks()
@@ -123,7 +127,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.progress.setValue(0)
 
     def _collect_actions(self):
-        actions = {action.text(): action for action in self.findChildren(QtWidgets.QAction)}
+        actions = {action.text(): action for action in self.findChildren(QtGui.QAction)}
         self._open_action = actions.get("Open...")
         self._save_recipe_action = actions.get("Save Recipe")
         self._save_recipe_as_action = actions.get("Save Recipe As...")
@@ -242,6 +246,76 @@ class MainWindow(QtWidgets.QMainWindow):
                 ordered.append(item)
         return ordered
 
+    def _refresh_recent_menu(self):
+        menu = getattr(self, "_recent_menu", None)
+        if not menu:
+            return
+        settings = self.appctx.settings
+        stored = self._coerce_settings_list(settings.value("recentFiles", []))
+        valid: List[str] = []
+        for entry in stored:
+            try:
+                path = Path(entry)
+            except (TypeError, ValueError):
+                continue
+            if path.exists():
+                valid.append(str(path))
+        limited = valid[:20]
+        if len(stored) != len(limited) or stored[: len(limited)] != limited:
+            settings.setValue("recentFiles", limited)
+        self._populate_recent_menu(limited)
+
+    def _populate_recent_menu(self, paths: List[str]):
+        menu = getattr(self, "_recent_menu", None)
+        if not menu:
+            return
+        menu.clear()
+        if not paths:
+            placeholder = menu.addAction(self._recent_placeholder_text)
+            placeholder.setEnabled(False)
+            return
+        for path in paths:
+            action = menu.addAction(path)
+            action.setData(path)
+            action.setToolTip(path)
+            action.triggered.connect(partial(self._open_recent_file, path))
+
+    def _preview_recent_menu(self, paths: List[str]):
+        preview = self._coerce_settings_list(paths)[:20]
+        self._populate_recent_menu(preview)
+
+    def _open_recent_file(self, path_str: str):
+        target = Path(path_str)
+        if not target.exists():
+            QtWidgets.QMessageBox.warning(
+                self,
+                "File Not Found",
+                f"The file '{path_str}' could not be found on disk.",
+            )
+            self._remove_recent_entry(path_str)
+            return
+
+        normalized = str(target)
+        lowered = normalized.lower()
+        if lowered.endswith(".recipe.json"):
+            self._load_recipe(target)
+        else:
+            self._set_queue([normalized])
+            base_dir = target.parent if target.is_file() else target
+            if base_dir.is_dir():
+                self._export_default_dir = base_dir
+                self.appctx.settings.setValue("export/defaultDir", str(base_dir))
+
+        self._record_recent_files([normalized])
+
+    def _remove_recent_entry(self, path_str: str):
+        settings = self.appctx.settings
+        current = self._coerce_settings_list(settings.value("recentFiles", []))
+        if path_str in current:
+            current.remove(path_str)
+            settings.setValue("recentFiles", current)
+            self._refresh_recent_menu()
+
     def _record_recent_files(self, paths: List[str]):
         clean_paths = [str(p) for p in paths if p]
         if not clean_paths:
@@ -253,6 +327,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 current.remove(path)
             current.insert(0, path)
         settings.setValue("recentFiles", current[:20])
+        self._refresh_recent_menu()
 
     def _connect_recipe_editor(self):
         self.recipeDock.module.currentTextChanged.connect(self._on_module_changed)
@@ -420,7 +495,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def on_settings(self):
         dialog = SettingsDialog(self.appctx.settings, self)
-        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+        dialog.recent_files_changed.connect(self._preview_recent_menu)
+        result = dialog.exec()
+        if result != QtWidgets.QDialog.DialogCode.Accepted:
+            self._refresh_recent_menu()
             return
 
         values = dialog.values()
@@ -446,6 +524,7 @@ class MainWindow(QtWidgets.QMainWindow):
             export_cfg["path"] = export_name
 
         self.status.showMessage("Settings updated.", 5000)
+        self._refresh_recent_menu()
 
     def on_check_updates(self):
         QtWidgets.QMessageBox.information(

--- a/spectro_app/ui/menus.py
+++ b/spectro_app/ui/menus.py
@@ -1,10 +1,18 @@
-from PyQt6.QtWidgets import QAction
+from PyQt6.QtGui import QAction
+
+
+_RECENT_PLACEHOLDER_TEXT = "No Recent Files"
+
 
 def build_menus(window):
     menubar = window.menuBar()
 
     file_menu = menubar.addMenu("&File")
     file_menu.addAction(_act(window, "Open...", shortcut="Ctrl+O", slot=window.on_open))
+    recent_menu = file_menu.addMenu("Open Recent")
+    recent_menu.setObjectName("openRecentMenu")
+    window._recent_menu = recent_menu
+    window._recent_placeholder_text = _RECENT_PLACEHOLDER_TEXT
     file_menu.addAction(_act(window, "Save Recipe", shortcut="Ctrl+S", slot=window.on_save_recipe))
     file_menu.addAction(_act(window, "Save Recipe As...", slot=window.on_save_recipe_as))
     file_menu.addSeparator()


### PR DESCRIPTION
## Summary
- add a File > Open Recent submenu that is populated from the stored recent file list
- refresh the menu after recent file updates, integrate Settings dialog edits, and handle missing targets gracefully
- add tests covering empty, pruned, and trimmed recent menu cases

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e193bd3c748324b555e76dfb1d04bb