### PR TITLE
Update README with setup and troubleshooting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # SpectroProtz
+
+## Overview
+SpectroProtz is a PyQt-based desktop application for managing spectroscopy
+batches, visualising spectra, and exporting analysis artefacts. The GUI bundles
+processing helpers, batch orchestration, and recipe management behind a single
+entry point so analysts can focus on domain workflows instead of wiring
+individual scripts. Internally, the launcher hands control to
+[`spectro_app/main.py`](spectro_app/main.py), which wires up the Qt event loop
+and the shared application context.
+
+## Prerequisites
+Ensure your environment matches the expectations declared in
+[`pyproject.toml`](pyproject.toml):
+
+- Python **3.10 or newer** (`requires-python = ">=3.10"`).
+- Qt bindings via **PyQt6 >= 6.6**.
+- Scientific stack: **numpy >= 1.26**, **scipy >= 1.12**, **pandas >= 2.0**,
+  **matplotlib >= 3.8**, **pyqtgraph >= 0.13**.
+- File/utility helpers: **openpyxl >= 3.1**, **pillow >= 10.0**, **PyYAML >= 6.0**.
+
+A typical workflow uses a virtual environment so the above packages can be
+installed without affecting system Python.
+
+## Setup
+From a fresh checkout:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
+pip install --upgrade pip
+pip install -e .
+```
+
+The editable install exposes the `spectro_app` package to your interpreter
+while keeping the source tree editable for rapid iteration.
+
+## Launching the GUI
+Once dependencies are installed and the virtual environment is active, start the
+application by running:
+
+```bash
+python -m spectro_app.main
+```
+
+This command bootstraps the Qt event loop and shows the main window immediately,
+allowing users to load recipes, configure processing options, and monitor batch
+runs.
+
+## Troubleshooting settings and configuration
+SpectroProtz persists user preferences with
+[`QSettings("SpectroLab", "SpectroApp")`](spectro_app/app_context.py). On most
+systems the store resolves to:
+
+- **Linux**: `~/.config/SpectroLab/SpectroApp.conf`
+- **macOS**: `~/Library/Preferences/com.SpectroLab.SpectroApp.plist`
+- **Windows**: Registry under `HKEY_CURRENT_USER\\Software\\SpectroLab\\SpectroApp`
+
+If widgets appear with stale values or the application fails to remember recent
+files, clear or rename the corresponding store before relaunching the GUI. After
+resetting settings, review the default configuration in
+[`spectro_app/config/defaults.yaml`](spectro_app/config/defaults.yaml) and the
+workflow reference in [`docs/workflow_overview.md`](docs/workflow_overview.md)
+for guidance on expected processing behaviour.


### PR DESCRIPTION
## Summary
- rewrite the README to describe the SpectroProtz GUI, its entry point, and dependency expectations
- document environment setup commands and how to launch the application via `python -m spectro_app.main`
- add troubleshooting guidance for the QSettings store and link to configuration references

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e385c48bc0832488b71dcc0cb26350