### PR TITLE
Add UV-Vis narrative exports and surface summaries

### DIFF
--- a/spectro_app/engine/plugin_api.py
+++ b/spectro_app/engine/plugin_api.py
@@ -14,6 +14,7 @@ class BatchResult:
     qc_table: List[Dict[str, Any]]
     figures: Dict[str, bytes]       # PNG/SVG bytes
     audit: List[str]
+    report_text: Optional[str] = None
 
 class SpectroscopyPlugin:
     id: str = "base"

--- a/spectro_app/plugins/ftir/plugin.py
+++ b/spectro_app/plugins/ftir/plugin.py
@@ -19,4 +19,10 @@ class FtirPlugin(SpectroscopyPlugin):
         return specs
 
     def export(self, specs, qc, recipe):
-        return BatchResult(processed=specs, qc_table=qc, figures={}, audit=["FTIR export stub"])
+        return BatchResult(
+            processed=specs,
+            qc_table=qc,
+            figures={},
+            audit=["FTIR export stub"],
+            report_text=None,
+        )

--- a/spectro_app/plugins/pees/plugin.py
+++ b/spectro_app/plugins/pees/plugin.py
@@ -19,4 +19,10 @@ class PeesPlugin(SpectroscopyPlugin):
         return specs
 
     def export(self, specs, qc, recipe):
-        return BatchResult(processed=specs, qc_table=qc, figures={}, audit=["PEES export stub"])
+        return BatchResult(
+            processed=specs,
+            qc_table=qc,
+            figures={},
+            audit=["PEES export stub"],
+            report_text=None,
+        )

--- a/spectro_app/plugins/raman/plugin.py
+++ b/spectro_app/plugins/raman/plugin.py
@@ -19,4 +19,10 @@ class RamanPlugin(SpectroscopyPlugin):
         return specs
 
     def export(self, specs, qc, recipe):
-        return BatchResult(processed=specs, qc_table=qc, figures={}, audit=["Raman export stub"])
+        return BatchResult(
+            processed=specs,
+            qc_table=qc,
+            figures={},
+            audit=["Raman export stub"],
+            report_text=None,
+        )

--- a/spectro_app/tests/test_main_window_runcontroller.py
+++ b/spectro_app/tests/test_main_window_runcontroller.py
@@ -48,6 +48,7 @@ class _DummyPlugin(SpectroscopyPlugin):
             qc_table=list(qc),
             figures={"Result": figure_bytes},
             audit=["analysis complete"],
+            report_text="Dummy narrative summary.",
         )
 
 
@@ -82,7 +83,9 @@ def test_run_controller_populates_docks(qt_app):
         assert window.qcDock.model.rowCount() == 1
 
         log_text = window.loggerDock.text.toPlainText()
+        assert "Dummy narrative summary." in log_text
         assert "analysis complete" in log_text
+        assert log_text.index("Dummy narrative summary.") < log_text.index("analysis complete")
     finally:
         window.close()
         window.deleteLater()

--- a/spectro_app/tests/test_uvvis_export.py
+++ b/spectro_app/tests/test_uvvis_export.py
@@ -148,6 +148,9 @@ def test_uvvis_export_creates_workbook_with_derivatives(tmp_path):
     assert result.figures, "Export should include generated plots"
     assert "qc_summary_noise.png" in result.figures
     assert any("Workbook written" in entry for entry in result.audit)
+    assert result.report_text, "Narrative report text should be populated"
+    for heading in ("Ingestion", "Pre-processing", "Analysis", "Results"):
+        assert heading in result.report_text
 
 
 def test_uvvis_export_generates_noise_histogram_and_trend(tmp_path):

--- a/spectro_app/ui/main_window.py
+++ b/spectro_app/ui/main_window.py
@@ -1102,7 +1102,14 @@ class MainWindow(QtWidgets.QMainWindow):
             self._last_result = result
             self.previewDock.show_batch_result(result)
             self.qcDock.show_qc_table(result.qc_table)
+            narrative_displayed = False
+            if result.report_text:
+                for line in result.report_text.splitlines():
+                    self.loggerDock.append_line(line)
+                narrative_displayed = True
             if result.audit:
+                if narrative_displayed:
+                    self.loggerDock.append_line("")
                 self.loggerDock.stream_lines(result.audit)
             else:
                 self.loggerDock.append_line("No audit messages were produced.")


### PR DESCRIPTION
## Summary
- extend the plugin BatchResult to carry an optional narrative text field and ensure every plugin populates it
- capture UV-Vis pipeline context to build a multi-section text report that is surfaced in exports, PDFs, and the main window logger
- update regression coverage so the dummy UI plugin and UV-Vis export tests assert the new report text behaviour

## Testing
- pytest spectro_app/tests/test_main_window_runcontroller.py spectro_app/tests/test_uvvis_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e3ad7952208324b0ea3fe2a10c639a