### PR TITLE
Ensure recipe editor defaults sync to recipe model

### DIFF
--- a/spectro_app/tests/test_recipe_editor_defaults.py
+++ b/spectro_app/tests/test_recipe_editor_defaults.py
@@ -1,0 +1,31 @@
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PyQt6.QtWidgets", exc_type=ImportError)
+from PyQt6 import QtWidgets  # type: ignore  # noqa: E402
+
+from spectro_app.ui.docks.recipe_editor import RecipeEditorDock  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    app.setQuitOnLastWindowClosed(False)
+    return app
+
+
+def test_recipe_editor_default_blank_flags(qt_app):
+    dock = RecipeEditorDock()
+    try:
+        recipe = dock.get_recipe()
+        blank_cfg = recipe.params.get("blank") or {}
+        assert blank_cfg.get("subtract") is False
+        assert blank_cfg.get("require") is False
+    finally:
+        dock.deleteLater()
+        qt_app.processEvents()


### PR DESCRIPTION
## Summary
- synchronize the recipe model with the widget defaults immediately after populating the UI so blank settings are preserved
- add a helper that forces model updates while updates are suspended to avoid triggering signal cascades
- add a Qt regression test that confirms the default recipe keeps blank subtraction and requirement disabled

## Testing
- pytest spectro_app/tests/test_recipe_editor_defaults.py


------
https://chatgpt.com/codex/tasks/task_e_68e3e6c1667c8324bbdde86c10e8aa21