### PR TITLE
Support queue overrides for blank spectra

### DIFF
--- a/spectro_app/tests/test_uvvis_queue_overrides.py
+++ b/spectro_app/tests/test_uvvis_queue_overrides.py
@@ -1,0 +1,31 @@
+from spectro_app.plugins.uvvis.plugin import UvVisPlugin
+
+
+def _write_simple_csv(path):
+    path.write_text("Wavelength,SampleA\n200,0.10\n210,0.11\n", encoding="utf-8")
+
+
+def test_queue_override_marks_blank(tmp_path):
+    csv_path = tmp_path / "sample.csv"
+    _write_simple_csv(csv_path)
+    plugin = UvVisPlugin(enable_manifest=False)
+
+    specs = plugin.load([str(csv_path)])
+    assert specs
+    assert specs[0].meta.get("role") == "sample"
+
+    plugin.set_queue_overrides({str(csv_path): {"role": "blank", "blank_id": "C1"}})
+    specs = plugin.load([str(csv_path)])
+    assert specs[0].meta.get("role") == "blank"
+    assert specs[0].meta.get("blank_id") == "C1"
+
+
+def test_queue_override_blank_id_defaults(tmp_path):
+    csv_path = tmp_path / "blank.csv"
+    _write_simple_csv(csv_path)
+    plugin = UvVisPlugin(enable_manifest=False)
+
+    plugin.set_queue_overrides({str(csv_path): {"role": "blank"}})
+    specs = plugin.load([str(csv_path)])
+    assert specs[0].meta.get("role") == "blank"
+    assert specs[0].meta.get("blank_id") in {"SampleA", "blank"}


### PR DESCRIPTION
## Summary
- add role override controls to the file queue context menu, including blank ID editing and override propagation
- forward queue overrides from the main window to plugins when starting runs
- teach the UV-Vis plugin to honour queue overrides and add regression tests

## Testing
- pytest spectro_app/tests/test_uvvis_queue_overrides.py

------
https://chatgpt.com/codex/tasks/task_e_68e3e85aaa68832498abcc6174b52ca1