### PR TITLE
Add configurable blank matching strategy for UV-Vis pipeline

### DIFF
--- a/docs/uvvis_signal_processing_reference.md
+++ b/docs/uvvis_signal_processing_reference.md
@@ -61,7 +61,7 @@
 ## Replicate Management
 
 ### `replicate_key`
-- Builds a `(role, identifier)` tuple so blanks and samples group independently even when metadata is sparse.
+- Builds a `(role, identifier)` tuple so blanks and samples group independently even when metadata is sparse, defaulting to blank identifiers unless a slot-based strategy is supplied via the higher-level helpers.
 
 ### `_replicate_feature_matrix`
 - Generates robust summary features (bias, mean, spread, slope, energy, area) for each replicate, normalising feature columns to stabilise downstream scoring.
@@ -70,12 +70,24 @@
 - Fills missing intensity values, derives the replicate feature matrix, computes leverage, fits a multivariate least squares model, and produces Cook’s distance scores for outlier screening.
 
 ### `average_replicates`
-- Groups spectra by replicate key, applies optional MAD- or Cook’s-distance outlier rejection, averages the retained traces, and records provenance, outlier metrics, and segment metadata for each group.
+- Groups spectra by replicate key, applies optional MAD- or Cook’s-distance outlier rejection, averages the retained traces, and records provenance, outlier metrics, and segment metadata for each group. Callers may supply a custom key function so blanks can be grouped using cuvette slots instead of legacy identifiers.
+
+### `blank_match_identifier`
+- Returns the primary identifier for a blank spectrum according to the configured match strategy, preferring cuvette slots when requested and gracefully falling back to legacy identifiers when slot metadata is absent.
+
+### `blank_match_identifiers`
+- Enumerates all viable identifiers for matching a blank (slot, explicit blank ID, sample ID, channel), enabling downstream lookups to support both slot-based and legacy association in a single pass.
+
+### `blank_replicate_key`
+- Builds replicate keys for blanks using the active match strategy so that averaging collapses slot-based replicates even when their `blank_id` values differ.
+
+### `normalize_blank_match_strategy`
+- Canonicalises user-provided strategy strings (e.g. `"slot"`, `"cuvette-slot"`) into the supported tokens (`"blank_id"` or `"cuvette_slot"`).
 
 ## Blank Identification
 
 ### `blank_identifier`
-- Emits a stable identifier for blank spectra based on blank, sample, or channel metadata when the role is “blank,” returning `None` otherwise.
+- Emits a stable identifier for blank spectra based on the selected match strategy—preferring cuvette slots when enabled and otherwise using blank/sample/channel metadata—returning `None` for non-blank roles.
 
 ## Intensity Mode Harmonisation
 

--- a/docs/workflow_overview.md
+++ b/docs/workflow_overview.md
@@ -111,10 +111,14 @@ The preprocessing stage honours the following recipe keys:
   `ValueError`s.【F:spectro_app/plugins/uvvis/plugin.py†L80-L188】【F:spectro_app/plugins/uvvis/plugin.py†L927-L978】
 - **Blank handling** – `blank.subtract`, `blank.require`,
   `blank.validate_metadata`, `blank.default`/`blank.fallback`,
-  `blank.max_time_delta_minutes` (default 240 minutes) and
-  `blank.pathlength_tolerance_cm` (default 0.01 cm) govern subtraction and
-  guard-rails. Time windows should reflect instrument drift; stick to
-  sub-day spans unless long acquisitions demand otherwise.【F:spectro_app/plugins/uvvis/plugin.py†L60-L78】【F:spectro_app/plugins/uvvis/plugin.py†L978-L1050】
+  `blank.match_strategy`, `blank.max_time_delta_minutes`
+  (default 240 minutes) and `blank.pathlength_tolerance_cm` (default 0.01 cm)
+  govern subtraction and guard-rails. Time windows should reflect instrument
+  drift; stick to sub-day spans unless long acquisitions demand otherwise.
+  Set `blank.match_strategy` to `cuvette_slot` when blanks should be grouped
+  and matched via `meta["cuvette_slot"]`; the pipeline automatically falls
+  back to legacy blank identifiers when slot metadata is unavailable so
+  existing recipes continue to work.【F:spectro_app/plugins/uvvis/plugin.py†L60-L78】【F:spectro_app/plugins/uvvis/plugin.py†L978-L1268】
 - **Join detection/correction** – `join.enabled`, `join.window`,
   `join.threshold`, `join.windows`, `join.offset_bounds`, `join.min_offset` and
   `join.max_offset` manage detector stitching. Windows are provided per


### PR DESCRIPTION
## Summary
- add a configurable `blank.match_strategy` for UV-Vis recipes and surface it in the recipe editor
- update pipeline preprocessing and helper utilities so blank averaging and lookup respect cuvette-slot matching with graceful fallbacks
- extend unit tests and documentation to cover both blank-id and cuvette-slot association modes

## Testing
- pytest spectro_app/tests/test_pipeline_uvvis.py

------
https://chatgpt.com/codex/tasks/task_e_68e42d8c921c832494fc206859d0c9bb