### PR TITLE
Hide manifest UI when UV-Vis disables manifests

### DIFF
--- a/spectro_app/plugins/uvvis/plugin.py
+++ b/spectro_app/plugins/uvvis/plugin.py
@@ -97,6 +97,11 @@ class UvVisPlugin(SpectroscopyPlugin):
         self._queue_overrides: Dict[str, Dict[str, object]] = {}
         self._reset_report_context()
 
+    def supports_manifest_ui(self) -> bool:
+        """Return whether the plugin should expose manifest-related UI."""
+
+        return bool(self.enable_manifest)
+
     def _reset_report_context(self) -> None:
         self._report_context = {
             "ingestion": {

--- a/spectro_app/ui/docks/file_queue.py
+++ b/spectro_app/ui/docks/file_queue.py
@@ -382,11 +382,13 @@ class FileQueueDock(QDockWidget):
         if not ordered_paths:
             return
 
+        plugin = self._resolve_plugin_for_paths(ordered_paths)
+        manifest_ui_enabled = self._plugin_supports_manifest_ui(plugin)
+
         manifest_paths: List[Path] = []
         data_paths: List[Path] = []
-        plugin = self._resolve_plugin_for_paths(ordered_paths)
 
-        if plugin and hasattr(plugin, "_is_manifest_file"):
+        if manifest_ui_enabled and plugin and hasattr(plugin, "_is_manifest_file"):
             for path in ordered_paths:
                 try:
                     is_manifest = bool(plugin._is_manifest_file(path))  # type: ignore[attr-defined]
@@ -453,6 +455,27 @@ class FileQueueDock(QDockWidget):
             return self._plugin_resolver([str(p) for p in paths])
         except Exception:
             return None
+
+    @staticmethod
+    def _plugin_supports_manifest_ui(plugin: Optional[object]) -> bool:
+        if not plugin or not hasattr(plugin, "_is_manifest_file"):
+            return False
+
+        supports_manifest = getattr(plugin, "supports_manifest_ui", None)
+        if callable(supports_manifest):
+            try:
+                return bool(supports_manifest())
+            except Exception:
+                return True
+
+        expose_attr = getattr(plugin, "expose_manifest_ui", None)
+        if expose_attr is None:
+            return True
+
+        try:
+            return bool(expose_attr()) if callable(expose_attr) else bool(expose_attr)
+        except Exception:
+            return True
 
     # ------------------------------------------------------------------
     # Context menu actions

--- a/spectro_app/ui/main_window.py
+++ b/spectro_app/ui/main_window.py
@@ -782,13 +782,16 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             technique_label = None
 
-        manifest_supported = bool(active_plugin and hasattr(active_plugin, "_is_manifest_file"))
+        manifest_detection_available = bool(
+            active_plugin and hasattr(active_plugin, "_is_manifest_file")
+        )
+        manifest_supported = self._plugin_supports_manifest_ui(active_plugin)
         manifest_entries: List[Dict[str, object]] = []
         manifest_lookup: Dict[str, Dict[str, Dict[str, object]]] = {}
         manifest_files: set[str] = set()
         manifest_errors: set[str] = set()
 
-        if manifest_supported:
+        if manifest_detection_available:
             for path_str in normalized:
                 path_obj = Path(path_str)
                 try:
@@ -797,7 +800,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     is_manifest = False
                 if is_manifest:
                     manifest_files.add(path_str)
-                    if hasattr(active_plugin, "_parse_manifest_file"):
+                    if manifest_supported and hasattr(active_plugin, "_parse_manifest_file"):
                         try:
                             parsed = active_plugin._parse_manifest_file(path_obj)  # type: ignore[attr-defined]
                         except Exception:
@@ -805,7 +808,11 @@ class MainWindow(QtWidgets.QMainWindow):
                         else:
                             if parsed:
                                 manifest_entries.extend(parsed)
-            if manifest_entries and hasattr(active_plugin, "_build_manifest_lookup"):
+            if (
+                manifest_supported
+                and manifest_entries
+                and hasattr(active_plugin, "_build_manifest_lookup")
+            ):
                 try:
                     manifest_lookup = active_plugin._build_manifest_lookup(manifest_entries)  # type: ignore[attr-defined]
                 except Exception:
@@ -814,12 +821,15 @@ class MainWindow(QtWidgets.QMainWindow):
         entries: List[QueueEntry] = []
         for path_str in normalized:
             path_obj = Path(path_str)
-            is_manifest = path_str in manifest_files
-            manifest_status: Optional[str]
+            is_manifest_candidate = path_str in manifest_files
+            is_manifest = bool(is_manifest_candidate and manifest_supported)
+            manifest_status: Optional[str] = None
             manifest_meta: Dict[str, object] = {}
 
             if active_plugin is None:
                 manifest_status = None
+            elif is_manifest_candidate and not manifest_supported:
+                manifest_status = "unsupported"
             elif is_manifest:
                 manifest_status = "manifest-error" if path_str in manifest_errors else "manifest"
             elif manifest_supported:
@@ -838,8 +848,6 @@ class MainWindow(QtWidgets.QMainWindow):
                     manifest_status = "missing"
                 else:
                     manifest_status = "none"
-            else:
-                manifest_status = "unsupported"
 
             role: Optional[str] = None
             mode: Optional[str] = None
@@ -851,7 +859,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 if isinstance(mode_value, str):
                     mode = mode_value.strip().lower() or None
 
-            metadata = dict(manifest_meta)
+            metadata = dict(manifest_meta) if manifest_supported else {}
             display_name = path_obj.name or path_str
             entries.append(
                 QueueEntry(
@@ -868,6 +876,27 @@ class MainWindow(QtWidgets.QMainWindow):
             )
 
         return entries
+
+    @staticmethod
+    def _plugin_supports_manifest_ui(plugin: Optional[object]) -> bool:
+        if not plugin or not hasattr(plugin, "_is_manifest_file"):
+            return False
+
+        supports_manifest = getattr(plugin, "supports_manifest_ui", None)
+        if callable(supports_manifest):
+            try:
+                return bool(supports_manifest())
+            except Exception:
+                return True
+
+        expose_attr = getattr(plugin, "expose_manifest_ui", None)
+        if expose_attr is None:
+            return True
+
+        try:
+            return bool(expose_attr()) if callable(expose_attr) else bool(expose_attr)
+        except Exception:
+            return True
 
     def _refresh_queue_metadata(self) -> None:
         if not self._queued_paths:


### PR DESCRIPTION
## Summary
- add a `supports_manifest_ui` capability to the UV-Vis plugin so manifests can remain hidden when disabled
- skip manifest detection, confirmations, and metadata badges in the file queue when the plugin opts out of manifest UI
- suppress manifest metadata joins in the main window when manifests are hidden

## Testing
- python -m compileall spectro_app/ui/docks/file_queue.py spectro_app/ui/main_window.py spectro_app/plugins/uvvis/plugin.py


------
https://chatgpt.com/codex/tasks/task_e_68e66838dabc83249928dabf7e7106ee