### PR TITLE
Clarify deprecated manifest flow and harden UV-Vis defaults

### DIFF
--- a/docs/workflow_overview.md
+++ b/docs/workflow_overview.md
@@ -12,16 +12,17 @@ Batches started through `RunController` fan out work onto the global Qt thread
 pool. Each run executes the following stages in order:
 
 1. **Load** – the plugin's `load` hook reads spectra from the supplied paths and
-   normalises metadata. The stage is responsible for optional manifest joins
-   and raw file decoding.【F:spectro_app/engine/run_controller.py†L10-L38】【F:spectro_app/plugins/uvvis/plugin.py†L171-L313】
+   normalises metadata. The stage is responsible for optional (deprecated)
+   manifest joins and raw file decoding.【F:spectro_app/engine/run_controller.py†L10-L38】【F:spectro_app/plugins/uvvis/plugin.py†L171-L313】
    - *Normalises metadata* means that each spectrum's `meta` dict is cleaned so
      keys/values follow a predictable format (e.g. lower-casing roles,
      back-filling `blank_id`, defaulting the technique and source file). This
      prevents downstream code from juggling per-file quirks.【F:spectro_app/plugins/uvvis/plugin.py†L232-L309】
    - *Manifest join* refers to the merge between parsed manifest rows and the
-     instrument metadata. The loader builds lookups by file, sample and channel
-     so that the most specific manifest entry wins before copying its fields
-     into each spectrum.【F:spectro_app/plugins/uvvis/plugin.py†L214-L355】
+     instrument metadata when the deprecated manifest pathway is explicitly
+     enabled. The loader builds lookups by file, sample and channel so that the
+     most specific manifest entry wins before copying its fields into each
+     spectrum.【F:spectro_app/plugins/uvvis/plugin.py†L214-L355】
    - *Raw file decoding* covers the family of readers that convert vendor CSV,
      Excel or Helios `.dsp` exports into wavelength/intensity arrays while
      extracting header metadata and inferring blanks/modes.【F:spectro_app/plugins/uvvis/plugin.py†L248-L309】【F:spectro_app/plugins/uvvis/plugin.py†L758-L868】
@@ -141,8 +142,8 @@ The preprocessing stage honours the following recipe keys:
 
 ### Additional feature gates
 
-- **Manifest ingestion** – manifests are now opt-in. Instantiate
-  `UvVisPlugin(enable_manifest=True)` *and* enable the
+- **Manifest ingestion** – manifests are now deprecated and remain disabled by
+  default. Instantiate `UvVisPlugin(enable_manifest=True)` *and* enable the
   `manifest_enrichment` UI capability when CSV/Excel descriptors should be
   merged using the precedence described above. Leave the defaults in place to
   ignore manifests entirely.【F:spectro_app/plugins/uvvis/plugin.py†L90-L355】

--- a/spectro_app/debugCheckList.md
+++ b/spectro_app/debugCheckList.md
@@ -40,7 +40,7 @@ PEES: minimal CSV with missing metadata field.
 
  Context menu: “Inspect header”, “Preview raw”, “Locate on disk” work.
 
- Manifest CSV loads; bad mappings warn but don’t crash; missing blank → fallback to nearest-in-time with warning.
+ If the deprecated manifest enrichment is enabled, CSV loads and bad mappings warn but don’t crash; missing blank → fallback to nearest-in-time with warning. Default runs should ignore manifests without disruption.
 
 4) Plugin detection & switching
 
@@ -92,7 +92,7 @@ PEES
 
 8) Blank & baseline
 
- Blank mapping by manifest; if absent, nearest-in-time within window; pathlength mismatch warns.
+ Blank mapping honours deprecated manifest enrichment when explicitly enabled; otherwise nearest-in-time within window; pathlength mismatch warns.
 
  After blank subtraction: negative A allowed but flagged; values preserved.
 

--- a/spectro_app/featureList.md
+++ b/spectro_app/featureList.md
@@ -18,7 +18,7 @@ Input & ingestion
 
 Drag-and-drop files/folders; file queue with badges (technique, A/%T, blank/sample).
 
-Manifest CSV for sample↔blank mapping, groupings (dose/site), replicate IDs (optional enrichment; enable via `UvVisPlugin(enable_manifest=True)` with the `manifest_enrichment` UI capability when manifests should be merged).
+Deprecated manifest CSV enrichment for sample↔blank mapping, groupings (dose/site), replicate IDs (opt-in only—standard workflows ignore manifests unless `UvVisPlugin(enable_manifest=True)` is used together with the `manifest_enrichment` UI capability).
   - Columns (case-insensitive): `file` (optional; basename or path), `channel`/`column` (optional; raw trace label),
     `sample_id` (final label), `blank_id`, `replicate`/`replicate_id`, `group`/`group_id`, `role`, `notes`.
   - Rows without `file` act as defaults; matching prefers file+channel, then file+sample, then global fallbacks.

--- a/spectro_app/tests/test_io_uvvis.py
+++ b/spectro_app/tests/test_io_uvvis.py
@@ -18,7 +18,7 @@ Wavelength (nm);Absorbance
     path = tmp_path / "sample_helios.csv"
     path.write_text(helios_csv, encoding="utf-8")
 
-    plugin = UvVisPlugin(enable_manifest=True)
+    plugin = UvVisPlugin()
     spectra = plugin.load([str(path)])
 
     assert len(spectra) == 1
@@ -49,7 +49,7 @@ def test_helios_excel_parsing(tmp_path):
     path = tmp_path / "helios.xlsx"
     df.to_excel(path, index=False, header=False)
 
-    plugin = UvVisPlugin(enable_manifest=True)
+    plugin = UvVisPlugin()
     spectra = plugin.load([str(path)])
 
     assert len(spectra) == 1
@@ -79,7 +79,7 @@ wavelength,Sample A,Blank Control
     path = tmp_path / "generic.csv"
     path.write_text(generic_csv, encoding="utf-8")
 
-    plugin = UvVisPlugin(enable_manifest=True)
+    plugin = UvVisPlugin()
     spectra = plugin.load([str(path)])
 
     assert len(spectra) == 2
@@ -160,7 +160,7 @@ VISIONlite Scan Version 2.1
     path = tmp_path / "sample01.dsp"
     path.write_text(dsp_text, encoding="utf-8")
 
-    plugin = UvVisPlugin(enable_manifest=True)
+    plugin = UvVisPlugin()
     spectra = plugin.load([str(path)])
 
     assert len(spectra) == 1
@@ -189,7 +189,7 @@ wavelength,Sample
     path = tmp_path / "reflectance.csv"
     path.write_text(generic_csv, encoding="utf-8")
 
-    plugin = UvVisPlugin(enable_manifest=True)
+    plugin = UvVisPlugin()
     spectra = plugin.load([str(path)])
 
     assert len(spectra) == 1
@@ -270,7 +270,7 @@ priority.csv,Sample A,Treated-A,File-Blank,
     assert spec.meta.get("treatment") == "Default-Treatment"
 
 
-def test_manifest_metadata_ignored_when_disabled(tmp_path):
+def test_manifest_metadata_ignored_with_default_configuration(tmp_path):
     generic_csv = """wavelength,Sample A,Sample B,Blank Control
 200,0.100,0.200,0.010
 205,0.105,0.205,0.011
@@ -293,8 +293,8 @@ generic.csv,Blank Control,Blank-01,,ref-blank,QC,blank
     assert "Treated-A" in enabled_by_id
     assert enabled_by_id["Treated-A"].meta["replicate_id"] == "rep-1"
 
-    disabled_plugin = UvVisPlugin(enable_manifest=False)
-    disabled_spectra = disabled_plugin.load([str(data_path), str(manifest_path)])
+    default_plugin = UvVisPlugin()
+    disabled_spectra = default_plugin.load([str(data_path), str(manifest_path)])
 
     assert len(disabled_spectra) == 3
     disabled_by_id = {spec.meta["sample_id"]: spec for spec in disabled_spectra}
@@ -377,7 +377,7 @@ def test_manifest_alias_assignments_from_excel(tmp_path):
     assert blank_spec.meta["group_id"] == "QC"
 
 
-def test_manifest_named_csv_when_disabled(tmp_path):
+def test_manifest_named_csv_with_default_settings(tmp_path):
     content = """wavelength,Sample
 200,0.100
 205,0.110
@@ -385,7 +385,7 @@ def test_manifest_named_csv_when_disabled(tmp_path):
     path = tmp_path / "sample_manifest.csv"
     path.write_text(content, encoding="utf-8")
 
-    plugin = UvVisPlugin(enable_manifest=False)
+    plugin = UvVisPlugin()
     spectra = plugin.load([str(path)])
 
     assert len(spectra) == 1

--- a/spectro_app/tests/test_uvvis_queue_overrides.py
+++ b/spectro_app/tests/test_uvvis_queue_overrides.py
@@ -8,7 +8,7 @@ def _write_simple_csv(path):
 def test_queue_override_marks_blank(tmp_path):
     csv_path = tmp_path / "sample.csv"
     _write_simple_csv(csv_path)
-    plugin = UvVisPlugin(enable_manifest=False)
+    plugin = UvVisPlugin()
 
     specs = plugin.load([str(csv_path)])
     assert specs
@@ -23,7 +23,7 @@ def test_queue_override_marks_blank(tmp_path):
 def test_queue_override_blank_id_defaults(tmp_path):
     csv_path = tmp_path / "blank.csv"
     _write_simple_csv(csv_path)
-    plugin = UvVisPlugin(enable_manifest=False)
+    plugin = UvVisPlugin()
 
     plugin.set_queue_overrides({str(csv_path): {"role": "blank"}})
     specs = plugin.load([str(csv_path)])

--- a/spectro_app/ui/docks/file_queue.py
+++ b/spectro_app/ui/docks/file_queue.py
@@ -324,11 +324,11 @@ class FileQueueDock(QDockWidget):
     @staticmethod
     def _manifest_badge(status: Optional[str]) -> Optional[QueueBadge]:
         mapping = {
-            "linked": QueueBadge(text="Manifest", category="manifest-ok", tooltip="Manifest metadata linked"),
-            "missing": QueueBadge(text="No Manifest", category="manifest-missing", tooltip="No manifest entry matched"),
-            "none": QueueBadge(text="No Manifest", category="manifest-na", tooltip="No manifest provided"),
-            "unsupported": QueueBadge(text="Manifest N/A", category="manifest-na", tooltip="Plugin does not support manifests"),
-            "manifest-error": QueueBadge(text="Manifest ⚠", category="manifest-error", tooltip="Manifest metadata unavailable"),
+            "linked": QueueBadge(text="Manifest (deprecated)", category="manifest-ok", tooltip="Legacy manifest metadata applied; feature is deprecated"),
+            "missing": QueueBadge(text="Manifest Missing", category="manifest-missing", tooltip="Deprecated manifest file provided but no rows matched"),
+            "none": QueueBadge(text="No Manifest", category="manifest-na", tooltip="Manifests are ignored unless explicitly enabled"),
+            "unsupported": QueueBadge(text="Manifest N/A", category="manifest-na", tooltip="Plugin does not expose the deprecated manifest feature"),
+            "manifest-error": QueueBadge(text="Manifest ⚠", category="manifest-error", tooltip="Deprecated manifest metadata could not be read"),
         }
         if not status:
             return None
@@ -432,14 +432,15 @@ class FileQueueDock(QDockWidget):
             names += "\n…"
         message = (
             "Manifest files were detected along with spectra.\n\n"
-            "Include the manifests when updating the queue?"
+            "Manifest ingestion is deprecated and disabled by default; include the"
+            " manifests anyway when updating the queue?"
         )
         if names:
             message += f"\n\nDetected manifests:\n{names}"
 
         choice = QtWidgets.QMessageBox.question(
             self,
-            "Include Manifest Files?",
+            "Include Deprecated Manifest Files?",
             message,
             QtWidgets.QMessageBox.StandardButton.Yes
             | QtWidgets.QMessageBox.StandardButton.No


### PR DESCRIPTION
## Summary
- mark manifest ingestion as a deprecated, opt-in workflow across the feature list, workflow guide, and debug checklist
- update UV-Vis IO and queue override tests to exercise the default manifest-disabled behaviour while keeping coverage for legacy manifest ingestion
- refresh queue tooltips and prompts so manifest messaging notes the deprecated, opt-in status

## Testing
- pytest spectro_app/tests/test_io_uvvis.py spectro_app/tests/test_uvvis_queue_overrides.py

------
https://chatgpt.com/codex/tasks/task_e_68e682e4682c8324a38d05ef573eaed1