### PR TITLE
Handle Windows multiprocessing timeout fallbacks safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ platform support. On POSIX platforms with `SIGALRM`, the indexer arms an alarm
 inside the current process so the guard remains low-overhead while still
 raising the same timeout error types that callers expect. When `SIGALRM` is not
 available (notably Windows), the indexer and shared peak-detection helpers
-start the guarded operation in a separate process, enforce the wall-clock limit
-via `join(timeout)`, and terminate the child if it exceeds the budget. This
-multiprocessing fallback preserves the same timeout semantics but adds process
-startup overhead, so throughput can dip when many short fits are executed.
+attempt to start the guarded operation in a separate process, enforce the
+wall-clock limit via `join(timeout)`, and terminate the child if it exceeds the
+budget. If the operation cannot be pickled for multiprocessing (for example, a
+lambda or nested function), the guard logs a warning and runs the operation in
+process without a timeout. The multiprocessing fallback preserves timeout
+semantics when it can be used but adds process startup overhead, so throughput
+can dip when many short fits are executed.
 
 ## Prerequisites
 Ensure your environment matches the expectations declared in

--- a/scripts/jdxIndexBuilder.py
+++ b/scripts/jdxIndexBuilder.py
@@ -148,6 +148,16 @@ class FitTimeoutError(TimeoutError):
 T = TypeVar("T")
 
 
+def _multiprocessing_timeout_worker(  # type: ignore[no-untyped-def]
+    queue, operation: Callable[[], T]
+) -> None:
+    try:
+        result = operation()
+        queue.put(("result", result))
+    except Exception as exc:  # pragma: no cover - depends on runtime
+        queue.put(("error", exc))
+
+
 def _run_with_multiprocessing_timeout(
     seconds: float,
     operation: Callable[[], T],
@@ -157,16 +167,19 @@ def _run_with_multiprocessing_timeout(
         return operation()
     ctx = multiprocessing.get_context("spawn")
     result_queue = ctx.Queue(maxsize=1)
-
-    def _worker(queue):  # type: ignore[no-untyped-def]
-        try:
-            result = operation()
-            queue.put(("result", result))
-        except Exception as exc:  # pragma: no cover - depends on runtime
-            queue.put(("error", exc))
-
-    proc = ctx.Process(target=_worker, args=(result_queue,), daemon=True)
-    proc.start()
+    try:
+        proc = ctx.Process(
+            target=_multiprocessing_timeout_worker,
+            args=(result_queue, operation),
+            daemon=True,
+        )
+        proc.start()
+    except Exception as exc:
+        logger.warning(
+            "Multiprocessing timeout guard unavailable (%s); running operation without timeout.",
+            exc,
+        )
+        return operation()
     proc.join(seconds)
     if proc.is_alive():
         proc.terminate()

--- a/spectro_app/engine/peak_detection.py
+++ b/spectro_app/engine/peak_detection.py
@@ -101,6 +101,16 @@ class FitTimeoutError(TimeoutError):
 T = TypeVar("T")
 
 
+def _multiprocessing_timeout_worker(  # type: ignore[no-untyped-def]
+    queue, operation: Callable[[], T]
+) -> None:
+    try:
+        result = operation()
+        queue.put(("result", result))
+    except Exception as exc:  # pragma: no cover - depends on runtime
+        queue.put(("error", exc))
+
+
 def _run_with_multiprocessing_timeout(
     seconds: float,
     operation: Callable[[], T],
@@ -110,16 +120,19 @@ def _run_with_multiprocessing_timeout(
         return operation()
     ctx = multiprocessing.get_context("spawn")
     result_queue = ctx.Queue(maxsize=1)
-
-    def _worker(queue):  # type: ignore[no-untyped-def]
-        try:
-            result = operation()
-            queue.put(("result", result))
-        except Exception as exc:  # pragma: no cover - depends on runtime
-            queue.put(("error", exc))
-
-    proc = ctx.Process(target=_worker, args=(result_queue,), daemon=True)
-    proc.start()
+    try:
+        proc = ctx.Process(
+            target=_multiprocessing_timeout_worker,
+            args=(result_queue, operation),
+            daemon=True,
+        )
+        proc.start()
+    except Exception as exc:
+        logger.warning(
+            "Multiprocessing timeout guard unavailable (%s); running operation without timeout.",
+            exc,
+        )
+        return operation()
     proc.join(seconds)
     if proc.is_alive():
         proc.terminate()


### PR DESCRIPTION
### Motivation

- Windows runs were failing to index many JCAMP files due to multiprocessing pickling errors for nested worker callables, causing the timeout guard to raise "Can't get local object" and crash the worker processes.
- The timeout guards need a graceful fallback so unpicklable operations do not break indexing or peak detection on platforms without `SIGALRM`.

### Description

- Move the multiprocessing worker to a top-level function named `_multiprocessing_timeout_worker` in `scripts/jdxIndexBuilder.py` and `spectro_app/engine/peak_detection.py` so it is pickleable on Windows.
- Wrap `ctx.Process(...)` startup in a `try/except` and log a warning while running the provided operation without a timeout when process spawning fails (e.g., due to an unpicklable callable), preserving functionality instead of failing hard.
- Update the README `Timeout enforcement` section to document the new pickle-aware fallback behaviour when `SIGALRM` is unavailable.

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d98e185b08324af919688e2eb4d1e)